### PR TITLE
experiment with builder pattern

### DIFF
--- a/rapidfuzz-benches/benches/bench_osa.rs
+++ b/rapidfuzz-benches/benches/bench_osa.rs
@@ -33,12 +33,7 @@ fn benchmark(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::new("rapidfuzz", i), &(&s1, &s2), |b, val| {
             b.iter(|| {
-                black_box(distance::osa::distance(
-                    val.0.chars(),
-                    val.1.chars(),
-                    None,
-                    None,
-                ));
+                black_box(distance::osa::distance().compare(val.0.chars(), val.1.chars()));
             })
         });
 
@@ -48,7 +43,7 @@ fn benchmark(c: &mut Criterion) {
             &(&cached, &s2),
             |b, val| {
                 b.iter(|| {
-                    black_box(cached.distance(val.1.chars(), None, None));
+                    black_box(cached.distance().compare(val.1.chars()));
                 })
             },
         );

--- a/src/details/distance.rs
+++ b/src/details/distance.rs
@@ -4,6 +4,34 @@ use crate::HashableChar;
 pub trait MetricUsize {
     fn maximum(&self, len1: usize, len2: usize) -> usize;
 
+    // todo rename if we convert everything to use the builder pattern
+    fn distance_<Iter1, Iter2>(
+        &self,
+        s1: Iter1,
+        s2: Iter2,
+        score_cutoff: Option<usize>,
+        score_hint: Option<usize>,
+    ) -> Option<usize>
+    where
+        Iter1: IntoIterator,
+        Iter1::IntoIter: DoubleEndedIterator + Clone,
+        Iter2: IntoIterator,
+        Iter2::IntoIter: DoubleEndedIterator + Clone,
+        Iter1::Item: PartialEq<Iter2::Item> + HashableChar + Copy,
+        Iter2::Item: PartialEq<Iter1::Item> + HashableChar + Copy,
+    {
+        let s1_iter = s1.into_iter();
+        let s2_iter = s2.into_iter();
+        self._distance(
+            s1_iter.clone(),
+            s1_iter.count(),
+            s2_iter.clone(),
+            s2_iter.count(),
+            score_cutoff,
+            score_hint,
+        )
+    }
+
     fn _distance<Iter1, Iter2>(
         &self,
         s1: Iter1,
@@ -33,6 +61,34 @@ pub trait MetricUsize {
             }
         }
         Some(dist)
+    }
+
+    // todo rename if we convert everything to use the builder pattern
+    fn similarity_<Iter1, Iter2>(
+        &self,
+        s1: Iter1,
+        s2: Iter2,
+        score_cutoff: Option<usize>,
+        score_hint: Option<usize>,
+    ) -> Option<usize>
+    where
+        Iter1: IntoIterator,
+        Iter1::IntoIter: DoubleEndedIterator + Clone,
+        Iter2: IntoIterator,
+        Iter2::IntoIter: DoubleEndedIterator + Clone,
+        Iter1::Item: PartialEq<Iter2::Item> + HashableChar + Copy,
+        Iter2::Item: PartialEq<Iter1::Item> + HashableChar + Copy,
+    {
+        let s1_iter = s1.into_iter();
+        let s2_iter = s2.into_iter();
+        self._similarity(
+            s1_iter.clone(),
+            s1_iter.count(),
+            s2_iter.clone(),
+            s2_iter.count(),
+            score_cutoff,
+            score_hint,
+        )
     }
 
     fn _similarity<Iter1, Iter2>(
@@ -71,6 +127,34 @@ pub trait MetricUsize {
             }
         }
         Some(sim)
+    }
+
+    // todo rename if we convert everything to use the builder pattern
+    fn normalized_distance_<Iter1, Iter2>(
+        &self,
+        s1: Iter1,
+        s2: Iter2,
+        score_cutoff: Option<f64>,
+        score_hint: Option<f64>,
+    ) -> Option<f64>
+    where
+        Iter1: IntoIterator,
+        Iter1::IntoIter: DoubleEndedIterator + Clone,
+        Iter2: IntoIterator,
+        Iter2::IntoIter: DoubleEndedIterator + Clone,
+        Iter1::Item: PartialEq<Iter2::Item> + HashableChar + Copy,
+        Iter2::Item: PartialEq<Iter1::Item> + HashableChar + Copy,
+    {
+        let s1_iter = s1.into_iter();
+        let s2_iter = s2.into_iter();
+        self._normalized_distance(
+            s1_iter.clone(),
+            s1_iter.count(),
+            s2_iter.clone(),
+            s2_iter.count(),
+            score_cutoff,
+            score_hint,
+        )
     }
 
     fn _normalized_distance<Iter1, Iter2>(
@@ -119,6 +203,34 @@ pub trait MetricUsize {
             }
         }
         Some(norm_dist)
+    }
+
+    // todo rename if we convert everything to use the builder pattern
+    fn normalized_similarity_<Iter1, Iter2>(
+        &self,
+        s1: Iter1,
+        s2: Iter2,
+        score_cutoff: Option<f64>,
+        score_hint: Option<f64>,
+    ) -> Option<f64>
+    where
+        Iter1: IntoIterator,
+        Iter1::IntoIter: DoubleEndedIterator + Clone,
+        Iter2: IntoIterator,
+        Iter2::IntoIter: DoubleEndedIterator + Clone,
+        Iter1::Item: PartialEq<Iter2::Item> + HashableChar + Copy,
+        Iter2::Item: PartialEq<Iter1::Item> + HashableChar + Copy,
+    {
+        let s1_iter = s1.into_iter();
+        let s2_iter = s2.into_iter();
+        self._normalized_similarity(
+            s1_iter.clone(),
+            s1_iter.count(),
+            s2_iter.clone(),
+            s2_iter.count(),
+            score_cutoff,
+            score_hint,
+        )
     }
 
     fn _normalized_similarity<Iter1, Iter2>(

--- a/src/distance/damerau_levenshtein.rs
+++ b/src/distance/damerau_levenshtein.rs
@@ -32,7 +32,7 @@
 //! use rapidfuzz::distance::osa;
 //!
 //! assert_eq!(Some(2), damerau_levenshtein::distance("CA".chars(), "ABC".chars(), None, None));
-//! assert_eq!(Some(3), osa::distance("CA".chars(), "ABC".chars(), None, None));
+//! assert_eq!(3, osa::distance().compare("CA".chars(), "ABC".chars()));
 //! ```
 //!
 //! The handling of transpositions in the OSA distance is simpler, which makes it computationally less intensive.

--- a/src/distance/osa.rs
+++ b/src/distance/osa.rs
@@ -216,19 +216,18 @@ pub struct NoScoreCutoff;
 #[derive(Default, Clone)]
 pub struct WithScoreCutoff<T>(T);
 
+#[must_use]
 pub struct IndividualComparator<MetricType, ResultType, CutoffType> {
     score_cutoff: CutoffType,
     score_hint: Option<ResultType>,
     metric_type: PhantomData<MetricType>,
 }
 
-impl<MetricType, ResultType> Default
-    for IndividualComparator<MetricType, ResultType, NoScoreCutoff>
-{
-    fn default() -> Self {
+impl<MetricType, ResultType> IndividualComparator<MetricType, ResultType, NoScoreCutoff> {
+    fn new() -> Self {
         Self {
-            score_cutoff: Default::default(),
-            score_hint: Default::default(),
+            score_cutoff: NoScoreCutoff,
+            score_hint: None,
             metric_type: PhantomData,
         }
     }
@@ -431,19 +430,19 @@ impl IndividualComparator<NormSim, f64, WithScoreCutoff<f64>> {
 }
 
 pub fn distance() -> IndividualComparator<Dist, usize, NoScoreCutoff> {
-    IndividualComparator::default()
+    IndividualComparator::new()
 }
 
 pub fn similarity() -> IndividualComparator<Sim, usize, NoScoreCutoff> {
-    IndividualComparator::default()
+    IndividualComparator::new()
 }
 
 pub fn normalized_distance() -> IndividualComparator<NormDist, f64, NoScoreCutoff> {
-    IndividualComparator::default()
+    IndividualComparator::new()
 }
 
 pub fn normalized_similarity() -> IndividualComparator<NormSim, f64, NoScoreCutoff> {
-    IndividualComparator::default()
+    IndividualComparator::new()
 }
 
 pub struct BatchComparator<Elem1> {
@@ -451,6 +450,7 @@ pub struct BatchComparator<Elem1> {
     pm: BlockPatternMatchVector,
 }
 
+#[must_use]
 pub struct BatchComparatorBuilder<'a, Elem1, MetricType, ResultType, CutoffType> {
     cache: &'a BatchComparator<Elem1>,
     score_cutoff: CutoffType,
@@ -506,8 +506,8 @@ impl<'a, Elem1, MetricType, ResultType>
     fn new(cache: &'a BatchComparator<Elem1>) -> Self {
         Self {
             cache,
-            score_cutoff: Default::default(),
-            score_hint: Default::default(),
+            score_cutoff: NoScoreCutoff,
+            score_hint: None,
             metric_type: PhantomData,
         }
     }
@@ -676,28 +676,26 @@ where
     }
 
     /// Normalized distance calculated similar to [`normalized_distance`]
-    pub fn normalized_distance<'a>(
-        &'a self,
-    ) -> BatchComparatorBuilder<'a, Elem1, NormDist, f64, NoScoreCutoff> {
+    pub fn normalized_distance(
+        &self,
+    ) -> BatchComparatorBuilder<'_, Elem1, NormDist, f64, NoScoreCutoff> {
         BatchComparatorBuilder::new(self)
     }
 
     /// Normalized similarity calculated similar to [`normalized_similarity`]
-    pub fn normalized_similarity<'a>(
-        &'a self,
-    ) -> BatchComparatorBuilder<'a, Elem1, NormSim, f64, NoScoreCutoff> {
+    pub fn normalized_similarity(
+        &self,
+    ) -> BatchComparatorBuilder<'_, Elem1, NormSim, f64, NoScoreCutoff> {
         BatchComparatorBuilder::new(self)
     }
 
     /// Distance calculated similar to [`distance`]
-    pub fn distance<'a>(&'a self) -> BatchComparatorBuilder<'a, Elem1, Dist, usize, NoScoreCutoff> {
+    pub fn distance(&self) -> BatchComparatorBuilder<'_, Elem1, Dist, usize, NoScoreCutoff> {
         BatchComparatorBuilder::new(self)
     }
 
     /// Similarity calculated similar to [`similarity`]
-    pub fn similarity<'a>(
-        &'a self,
-    ) -> BatchComparatorBuilder<'a, Elem1, Sim, usize, NoScoreCutoff> {
+    pub fn similarity(&self) -> BatchComparatorBuilder<'_, Elem1, Sim, usize, NoScoreCutoff> {
         BatchComparatorBuilder::new(self)
     }
 }

--- a/src/distance/osa.rs
+++ b/src/distance/osa.rs
@@ -216,13 +216,15 @@ pub struct NoScoreCutoff;
 #[derive(Default, Clone)]
 pub struct WithScoreCutoff<T>(T);
 
-pub struct IndividualComparator<T, ResultType, CutoffType> {
+pub struct IndividualComparator<MetricType, ResultType, CutoffType> {
     score_cutoff: CutoffType,
     score_hint: Option<ResultType>,
-    metric_type: PhantomData<T>,
+    metric_type: PhantomData<MetricType>,
 }
 
-impl<T, ResultType> Default for IndividualComparator<T, ResultType, NoScoreCutoff> {
+impl<MetricType, ResultType> Default
+    for IndividualComparator<MetricType, ResultType, NoScoreCutoff>
+{
     fn default() -> Self {
         Self {
             score_cutoff: Default::default(),
@@ -232,7 +234,9 @@ impl<T, ResultType> Default for IndividualComparator<T, ResultType, NoScoreCutof
     }
 }
 
-impl<T, ResultType, CutoffType> MetricUsize for IndividualComparator<T, ResultType, CutoffType> {
+impl<MetricType, ResultType, CutoffType> MetricUsize
+    for IndividualComparator<MetricType, ResultType, CutoffType>
+{
     fn maximum(&self, len1: usize, len2: usize) -> usize {
         len1.max(len2)
     }
@@ -292,7 +296,7 @@ impl<T, ResultType, CutoffType> MetricUsize for IndividualComparator<T, ResultTy
     }
 }
 
-impl<T, ResultType, CutoffType> IndividualComparator<T, ResultType, CutoffType> {
+impl<MetricType, ResultType, CutoffType> IndividualComparator<MetricType, ResultType, CutoffType> {
     pub fn with_score_hint(mut self, score_hint: impl Into<ResultType>) -> Self {
         self.score_hint = Some(score_hint.into());
         self
@@ -301,7 +305,7 @@ impl<T, ResultType, CutoffType> IndividualComparator<T, ResultType, CutoffType> 
     pub fn with_score_cutoff(
         self,
         score_cutoff: impl Into<ResultType>,
-    ) -> IndividualComparator<T, ResultType, WithScoreCutoff<ResultType>> {
+    ) -> IndividualComparator<MetricType, ResultType, WithScoreCutoff<ResultType>> {
         IndividualComparator {
             score_hint: self.score_hint,
             score_cutoff: WithScoreCutoff(score_cutoff.into()),
@@ -427,19 +431,19 @@ impl IndividualComparator<NormSim, f64, WithScoreCutoff<f64>> {
 }
 
 pub fn distance() -> IndividualComparator<Dist, usize, NoScoreCutoff> {
-    IndividualComparator::<Dist, usize, NoScoreCutoff>::default()
+    IndividualComparator::default()
 }
 
 pub fn similarity() -> IndividualComparator<Sim, usize, NoScoreCutoff> {
-    IndividualComparator::<Sim, usize, NoScoreCutoff>::default()
+    IndividualComparator::default()
 }
 
 pub fn normalized_distance() -> IndividualComparator<NormDist, f64, NoScoreCutoff> {
-    IndividualComparator::<NormDist, f64, NoScoreCutoff>::default()
+    IndividualComparator::default()
 }
 
 pub fn normalized_similarity() -> IndividualComparator<NormSim, f64, NoScoreCutoff> {
-    IndividualComparator::<NormSim, f64, NoScoreCutoff>::default()
+    IndividualComparator::default()
 }
 
 pub struct BatchComparator<Elem1> {
@@ -447,15 +451,15 @@ pub struct BatchComparator<Elem1> {
     pm: BlockPatternMatchVector,
 }
 
-pub struct BatchComparatorBuilder<'a, Elem1, T, ResultType, CutoffType> {
+pub struct BatchComparatorBuilder<'a, Elem1, MetricType, ResultType, CutoffType> {
     cache: &'a BatchComparator<Elem1>,
     score_cutoff: CutoffType,
     score_hint: Option<ResultType>,
-    metric_type: PhantomData<T>,
+    metric_type: PhantomData<MetricType>,
 }
 
-impl<Elem1, T, ResultType, CutoffType> MetricUsize
-    for BatchComparatorBuilder<'_, Elem1, T, ResultType, CutoffType>
+impl<Elem1, MetricType, ResultType, CutoffType> MetricUsize
+    for BatchComparatorBuilder<'_, Elem1, MetricType, ResultType, CutoffType>
 {
     fn maximum(&self, len1: usize, len2: usize) -> usize {
         len1.max(len2)
@@ -496,7 +500,9 @@ impl<Elem1, T, ResultType, CutoffType> MetricUsize
     }
 }
 
-impl<'a, Elem1, T, ResultType> BatchComparatorBuilder<'a, Elem1, T, ResultType, NoScoreCutoff> {
+impl<'a, Elem1, MetricType, ResultType>
+    BatchComparatorBuilder<'a, Elem1, MetricType, ResultType, NoScoreCutoff>
+{
     fn new(cache: &'a BatchComparator<Elem1>) -> Self {
         Self {
             cache,
@@ -507,8 +513,8 @@ impl<'a, Elem1, T, ResultType> BatchComparatorBuilder<'a, Elem1, T, ResultType, 
     }
 }
 
-impl<'a, Elem1, T, ResultType, CutoffType>
-    BatchComparatorBuilder<'a, Elem1, T, ResultType, CutoffType>
+impl<'a, Elem1, MetricType, ResultType, CutoffType>
+    BatchComparatorBuilder<'a, Elem1, MetricType, ResultType, CutoffType>
 {
     pub fn with_score_hint(mut self, score_hint: impl Into<ResultType>) -> Self {
         self.score_hint = Some(score_hint.into());
@@ -518,7 +524,8 @@ impl<'a, Elem1, T, ResultType, CutoffType>
     pub fn with_score_cutoff(
         self,
         score_cutoff: impl Into<ResultType>,
-    ) -> BatchComparatorBuilder<'a, Elem1, T, ResultType, WithScoreCutoff<ResultType>> {
+    ) -> BatchComparatorBuilder<'a, Elem1, MetricType, ResultType, WithScoreCutoff<ResultType>>
+    {
         BatchComparatorBuilder {
             cache: self.cache,
             score_hint: self.score_hint,
@@ -672,26 +679,26 @@ where
     pub fn normalized_distance<'a>(
         &'a self,
     ) -> BatchComparatorBuilder<'a, Elem1, NormDist, f64, NoScoreCutoff> {
-        BatchComparatorBuilder::<'a, Elem1, NormDist, f64, NoScoreCutoff>::new(self)
+        BatchComparatorBuilder::new(self)
     }
 
     /// Normalized similarity calculated similar to [`normalized_similarity`]
     pub fn normalized_similarity<'a>(
         &'a self,
     ) -> BatchComparatorBuilder<'a, Elem1, NormSim, f64, NoScoreCutoff> {
-        BatchComparatorBuilder::<'a, Elem1, NormSim, f64, NoScoreCutoff>::new(self)
+        BatchComparatorBuilder::new(self)
     }
 
     /// Distance calculated similar to [`distance`]
     pub fn distance<'a>(&'a self) -> BatchComparatorBuilder<'a, Elem1, Dist, usize, NoScoreCutoff> {
-        BatchComparatorBuilder::<'a, Elem1, Dist, usize, NoScoreCutoff>::new(self)
+        BatchComparatorBuilder::new(self)
     }
 
     /// Similarity calculated similar to [`similarity`]
     pub fn similarity<'a>(
         &'a self,
     ) -> BatchComparatorBuilder<'a, Elem1, Sim, usize, NoScoreCutoff> {
-        BatchComparatorBuilder::<'a, Elem1, Sim, usize, NoScoreCutoff>::new(self)
+        BatchComparatorBuilder::new(self)
     }
 }
 


### PR DESCRIPTION
This is a quick experiment how the builder pattern for the API would look and how much effort it would be. At least the tags for type and score cutoff could be shared between implementations. Not really sure whether we can reduce duplication further, since these public functions should probably have documentation, which might differ between metrics. In theory I could generate a lot of this using macros, but that's not necessarily an improvement :sweat_smile: 