### PR TITLE
Addition of WRatio

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,4 +1,59 @@
+use std::cmp::Ord;
 use std::fmt::Debug;
+use std::iter::Peekable;
+use std::vec::Vec;
+
+use crate::details::splitted_sentence::{is_space, IsSpace, SplittedSentence};
+use crate::HashableChar;
+
+/// Splits an input iterator into tokens based on whitespace, sorts them, and returns a `SplittedSentence`.
+///
+/// # Parameters
+/// - `input`: An iterator over the input sequence.
+///
+/// # Returns
+/// - A `SplittedSentence` containing sorted tokens.
+///
+/// # Notes
+/// - Tokens are split based on whitespace characters determined by the `is_space` function.
+/// - The function collects tokens into a vector of ranges or slices, sorts them, and constructs a `SplittedSentence`.
+pub fn sorted_split<Iter, CharT>(input: Iter) -> SplittedSentence<CharT>
+where
+    Iter: IntoIterator<Item = CharT>,
+    Iter::IntoIter: Clone + Iterator<Item = CharT>,
+    CharT: IsSpace + HashableChar + Copy + Ord,
+{
+    let mut splitted: Vec<Vec<CharT>> = Vec::new();
+    let mut iter = input.into_iter().peekable();
+
+    while let Some(&ch) = iter.peek() {
+        // Skip over any whitespace characters
+        if is_space(ch) {
+            iter.next();
+            continue;
+        }
+
+        // Collect the token
+        let mut token = Vec::new();
+        while let Some(&ch) = iter.peek() {
+            if is_space(ch) {
+                break;
+            }
+            token.push(ch);
+            iter.next();
+        }
+
+        if !token.is_empty() {
+            splitted.push(token);
+        }
+    }
+
+    // Sort the tokens
+    splitted.sort();
+
+    // Construct a SplittedSentence from the sorted tokens
+    SplittedSentence::new(splitted)
+}
 
 #[derive(Default, Copy, Clone)]
 pub struct NoScoreCutoff;

--- a/src/details.rs
+++ b/src/details.rs
@@ -4,3 +4,4 @@ pub mod growing_hashmap;
 pub mod intrinsics;
 pub mod matrix;
 pub mod pattern_match_vector;
+pub mod splitted_sentence;

--- a/src/details/splitted_sentence.rs
+++ b/src/details/splitted_sentence.rs
@@ -1,5 +1,5 @@
 use crate::HashableChar;
-use std::cmp::Ordering;
+
 // src/details/splitted_sentence.rs
 
 /// Trait to determine if a character is a whitespace and to provide a space character.

--- a/src/details/splitted_sentence.rs
+++ b/src/details/splitted_sentence.rs
@@ -1,0 +1,217 @@
+use crate::HashableChar;
+use std::cmp::Ordering;
+// src/details/splitted_sentence.rs
+
+/// Trait to determine if a character is a whitespace and to provide a space character.
+pub trait IsSpace: Sized + Copy {
+    /// Determines if the character is a whitespace character.
+    fn is_space(&self) -> bool;
+
+    /// Returns a space character of the same type.
+    fn space() -> Self;
+}
+
+impl IsSpace for char {
+    fn is_space(&self) -> bool {
+        matches!(
+            *self,
+            '\u{0009}' // TAB
+                | '\u{000A}' // LF
+                | '\u{000B}' // VT
+                | '\u{000C}' // FF
+                | '\u{000D}' // CR
+                | '\u{001C}'
+                | '\u{001D}'
+                | '\u{001E}'
+                | '\u{001F}'
+                | '\u{0020}' // SPACE
+                | '\u{0085}'
+                | '\u{00A0}'
+                | '\u{1680}'
+                | '\u{2000}'
+                | '\u{2001}'
+                | '\u{2002}'
+                | '\u{2003}'
+                | '\u{2004}'
+                | '\u{2005}'
+                | '\u{2006}'
+                | '\u{2007}'
+                | '\u{2008}'
+                | '\u{2009}'
+                | '\u{200A}'
+                | '\u{2028}'
+                | '\u{2029}'
+                | '\u{202F}'
+                | '\u{205F}'
+                | '\u{3000}'
+        )
+    }
+
+    fn space() -> Self {
+        ' '
+    }
+}
+
+impl IsSpace for u8 {
+    fn is_space(&self) -> bool {
+        matches!(
+            *self,
+            0x09 | 0x0A | 0x0B | 0x0C | 0x0D | 0x1C | 0x1D | 0x1E | 0x1F | 0x20
+        )
+    }
+
+    fn space() -> Self {
+        0x20 // ASCII space
+    }
+}
+
+/// Determines if a character is considered a whitespace character.
+///
+/// This function now operates on any type that implements the `IsSpace` trait.
+pub fn is_space<CharT: IsSpace>(ch: CharT) -> bool {
+    ch.is_space()
+}
+
+/// A view into a splitted sentence, containing sorted tokens.
+#[derive(Debug, Clone)]
+pub struct SplittedSentence<CharT> {
+    tokens: Vec<Vec<CharT>>,
+}
+
+impl<CharT> SplittedSentence<CharT>
+where
+    CharT: IsSpace + HashableChar + Copy + Ord,
+{
+    /// Creates a new `SplittedSentence` from a vector of token vectors.
+    pub fn new(tokens: Vec<Vec<CharT>>) -> Self {
+        SplittedSentence { tokens }
+    }
+
+    /// Removes duplicate tokens, keeping only unique tokens.
+    ///
+    /// Returns the number of duplicates removed.
+    pub fn dedupe(&mut self) -> usize {
+        let old_word_count = self.word_count();
+        self.tokens.sort();
+        self.tokens.dedup();
+        old_word_count - self.word_count()
+    }
+
+    /// Returns the total size (number of characters plus spaces) of the splitted sentence.
+    pub fn size(&self) -> usize {
+        if self.tokens.is_empty() {
+            return 0;
+        }
+
+        // There is a space between each word
+        let mut result = self.tokens.len() - 1;
+        for token in &self.tokens {
+            result += token.len();
+        }
+
+        result
+    }
+
+    /// Returns the length of the splitted sentence.
+    ///
+    /// This is an alias for `size`.
+    pub fn length(&self) -> usize {
+        self.size()
+    }
+
+    /// Checks if the splitted sentence is empty.
+    pub fn empty(&self) -> bool {
+        self.tokens.is_empty()
+    }
+
+    /// Returns the number of words (tokens) in the splitted sentence.
+    pub fn word_count(&self) -> usize {
+        self.tokens.len()
+    }
+
+    /// Joins the tokens back into a single vector of characters, separated by spaces.
+    pub fn join(&self) -> Vec<CharT> {
+        if self.tokens.is_empty() {
+            return Vec::new();
+        }
+
+        let mut joined = Vec::with_capacity(self.size());
+        joined.extend(&self.tokens[0]);
+
+        for token in self.tokens.iter().skip(1) {
+            joined.push(CharT::space());
+            joined.extend(token);
+        }
+
+        joined
+    }
+
+    /// Returns a reference to the internal tokens.
+    pub fn words(&self) -> &Vec<Vec<CharT>> {
+        &self.tokens
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_splitted_sentence_char() {
+        let tokens = vec![
+            vec!['f', 'u', 'z', 'z', 'y'],
+            vec!['w', 'u', 'z', 'z', 'y'],
+            vec!['w', 'a', 's'],
+            vec!['a'],
+            vec!['b', 'e', 'a', 'r'],
+        ];
+        let mut splitted = SplittedSentence::new(tokens.clone());
+        // 'fuzzy wuzzy was a bear' has 5 + 1 + 5 + 1 + 3 + 1 + 1 + 1 + 4 = 22 characters
+        assert_eq!(splitted.size(), 22);
+
+        let removed = splitted.dedupe();
+        // All tokens are unique, so dedupe should remove 0
+        assert_eq!(removed, 0);
+        assert_eq!(splitted.word_count(), 5);
+
+        let joined = splitted.join();
+        assert_eq!(
+            joined,
+            vec![
+                'f', 'u', 'z', 'z', 'y', ' ', 'w', 'u', 'z', 'z', 'y', ' ', 'w', 'a', 's', ' ',
+                'a', ' ', 'b', 'e', 'a', 'r'
+            ]
+        );
+    }
+
+    #[test]
+    fn test_splitted_sentence_u8() {
+        let tokens = vec![
+            vec![102, 117, 122, 122, 121], // "fuzzy"
+            vec![119, 117, 122, 122, 121], // "wuzzy"
+            vec![119, 97, 115],            // "was"
+            vec![97],                      // "a"
+            vec![98, 101, 97, 114],        // "bear"
+        ];
+        let mut splitted = SplittedSentence::new(tokens.clone());
+        // 'fuzzy wuzzy was a bear' has 5 + 1 + 5 + 1 + 3 + 1 + 1 + 1 + 4 = 22 characters
+        assert_eq!(splitted.size(), 22);
+
+        let removed = splitted.dedupe();
+        // All tokens are unique, so dedupe should remove 0
+        assert_eq!(removed, 0);
+        assert_eq!(splitted.word_count(), 5);
+
+        let joined = splitted.join();
+        assert_eq!(
+            joined,
+            vec![
+                102, 117, 122, 122, 121, 32, // "fuzzy "
+                119, 117, 122, 122, 121, 32, // "wuzzy "
+                119, 97, 115, 32, // "was "
+                97, 32, // "a "
+                98, 101, 97, 114 // "bear"
+            ]
+        );
+    }
+}

--- a/src/details/splitted_sentence.rs
+++ b/src/details/splitted_sentence.rs
@@ -92,8 +92,7 @@ where
     /// Returns the number of duplicates removed.
     pub fn dedupe(&mut self) -> usize {
         let old_word_count = self.word_count();
-        self.tokens.sort();
-        self.tokens.dedup();
+        self.tokens.dedup(); // Removes consecutive duplicates while preserving order.
         old_word_count - self.word_count()
     }
 

--- a/src/fuzz.rs
+++ b/src/fuzz.rs
@@ -1,20 +1,22 @@
 use crate::common::{
-    set_decomposition, sorted_split, NoScoreCutoff, SimilarityCutoff, WithScoreCutoff,
+    set_decomposition, sorted_split, NoScoreCutoff, ScoreAlignment, SimilarityCutoff,
+    WithScoreCutoff,
 };
 use crate::details::distance::MetricUsize;
 use crate::details::splitted_sentence::{IsSpace, SplittedSentence};
 use crate::distance::indel;
-use crate::HashableChar;
+use crate::{Hash, HashableChar};
+use std::collections::HashSet;
 
 pub fn score_cutoff_to_distance(score_cutoff: f64, lensum: usize) -> usize {
-    ((lensum as f64) * (1.0 - score_cutoff / 100.0)).ceil() as usize
+    ((lensum as f64) * (1.0 - score_cutoff)).ceil() as usize
 }
 
 pub fn norm_distance(dist: usize, lensum: usize, score_cutoff: f64) -> f64 {
     let score = if lensum > 0 {
-        100.0 - 100.0 * (dist as f64) / (lensum as f64)
+        1.0 - (dist as f64) / (lensum as f64)
     } else {
-        100.0
+        1.0
     };
 
     if score >= score_cutoff {
@@ -22,522 +24,6 @@ pub fn norm_distance(dist: usize, lensum: usize, score_cutoff: f64) -> f64 {
     } else {
         0.0
     }
-}
-
-/// Computes the token ratio between two sequences with additional arguments.
-///
-/// # Parameters
-/// - `s1`: The first sequence to compare.
-/// - `s2`: The second sequence to compare.
-/// - `args`: Additional arguments containing `score_cutoff` and `score_hint`.
-///
-/// # Returns
-/// - The token ratio between `s1` and `s2` or `None` if the computed ratio is below `score_cutoff`.
-pub fn token_ratio_with_args<Iter1, Iter2, SimCutoffType, CharT>(
-    s1: Iter1,
-    s2: Iter2,
-    args: &Args<f64, SimCutoffType>,
-) -> SimCutoffType::Output
-where
-    // Both Iter1 and Iter2 must produce the same CharT
-    Iter1: IntoIterator<Item = CharT>,
-    Iter2: IntoIterator<Item = CharT>,
-
-    // Add bounds for both iterators
-    Iter1::IntoIter: Clone + DoubleEndedIterator<Item = CharT>,
-    Iter2::IntoIter: Clone + DoubleEndedIterator<Item = CharT>,
-
-    // Add all the required trait bounds for CharT
-    CharT: HashableChar + Clone + Ord + IsSpace + Copy,
-
-    SimCutoffType: SimilarityCutoff<f64>,
-{
-    // Extract the score cutoff, default to 0.0
-    let score_cutoff_value: f64 = args.score_cutoff.cutoff().unwrap_or(0.0);
-
-    if score_cutoff_value > 100.0 {
-        return args.score_cutoff.score(0.0);
-    }
-
-    let s1_iter = s1.into_iter();
-    let s2_iter = s2.into_iter();
-
-    // Split and sort tokens
-    let tokens_a = sorted_split(s1_iter.clone());
-    let tokens_b = sorted_split(s2_iter.clone());
-
-    // Decompose into intersection and differences
-    let decomposition = set_decomposition(tokens_a.clone(), tokens_b.clone());
-    let intersect = decomposition.intersection;
-    let diff_ab = decomposition.difference_ab;
-    let diff_ba = decomposition.difference_ba;
-
-    // If intersection is not empty and either diff is empty, return 100.0
-    if !intersect.empty() && (diff_ab.empty() || diff_ba.empty()) {
-        return args.score_cutoff.score(100.0);
-    }
-
-    // Join the differences
-    let diff_ab_joined = diff_ab.join();
-    let diff_ba_joined = diff_ba.join();
-
-    // Lengths
-    let ab_len = diff_ab_joined.len();
-    let ba_len = diff_ba_joined.len();
-    let sect_len = intersect.length();
-
-    let tokens_a_joined = tokens_a.join();
-    let tokens_b_joined = tokens_b.join();
-
-    let result = ratio_with_args(tokens_a_joined.clone(), tokens_b_joined.clone(), args);
-
-    let mut result_value = match result.into() {
-        Some(r) => r,
-        None => return args.score_cutoff.score(0.0),
-    };
-
-    let sect_len_bool = if sect_len > 0 { 1 } else { 0 };
-    let sect_ab_len = sect_len + sect_len_bool + ab_len;
-    let sect_ba_len = sect_len + sect_len_bool + ba_len;
-    let total_len = sect_ab_len + sect_ba_len;
-
-    let cutoff_distance = score_cutoff_to_distance(score_cutoff_value, total_len);
-
-    // Create distance args with the correct type
-    let dist_args = indel::Args::<usize, WithScoreCutoff<usize>> {
-        score_cutoff: WithScoreCutoff(cutoff_distance),
-        score_hint: None,
-    };
-
-    // Pass by reference to distance_with_args
-    let dist =
-        crate::distance::indel::distance_with_args(diff_ab_joined, diff_ba_joined, &dist_args);
-
-    if let Some(distance) = dist {
-        if distance <= cutoff_distance {
-            let norm_dist = norm_distance(distance, total_len, score_cutoff_value);
-            result_value = result_value.max(norm_dist);
-        }
-    }
-
-    if sect_len == 0 {
-        return args.score_cutoff.score(result_value);
-    }
-
-    let sect_ab_dist = sect_len_bool + ab_len;
-    let sect_ab_total_len = sect_len + sect_ab_len;
-    let sect_ab_ratio = norm_distance(sect_ab_dist, sect_ab_total_len, score_cutoff_value);
-
-    let sect_ba_dist = sect_len_bool + ba_len;
-    let sect_ba_total_len = sect_len + sect_ba_len;
-    let sect_ba_ratio = norm_distance(sect_ba_dist, sect_ba_total_len, score_cutoff_value);
-
-    result_value = result_value.max(sect_ab_ratio.max(sect_ba_ratio));
-    args.score_cutoff.score(result_value)
-}
-
-pub fn partial_ratio_with_args<Iter1, Iter2, CutoffType, CharT>(
-    s1: Iter1,
-    s2: Iter2,
-    args: &Args<f64, CutoffType>,
-) -> CutoffType::Output
-where
-    // Both Iter1 and Iter2 must produce the same CharT
-    Iter1: IntoIterator<Item = CharT>,
-    Iter2: IntoIterator<Item = CharT>,
-
-    // Add bounds for both iterators
-    Iter1::IntoIter: Clone + DoubleEndedIterator<Item = CharT>,
-    Iter2::IntoIter: Clone + DoubleEndedIterator<Item = CharT>,
-
-    // Add all the required trait bounds for CharT
-    CharT: HashableChar + Clone + Ord + IsSpace + Copy,
-
-    CutoffType: SimilarityCutoff<f64>,
-{
-    // Extract the score cutoff, default to 0.0
-    let score_cutoff_value: f64 = args.score_cutoff.cutoff().unwrap_or(0.0);
-
-    if score_cutoff_value > 100.0 {
-        return args.score_cutoff.score(0.0);
-    }
-
-    let s1_iter = s1.into_iter();
-    let s2_iter = s2.into_iter();
-
-    // Split and sort tokens
-    let tokens_a = sorted_split(s1_iter.clone());
-    let tokens_b = sorted_split(s2_iter.clone());
-
-    // Decompose into intersection and differences
-    let decomposition = set_decomposition(tokens_a.clone(), tokens_b.clone());
-    let intersect = decomposition.intersection;
-    let diff_ab = decomposition.difference_ab;
-    let diff_ba = decomposition.difference_ba;
-
-    // If intersection is not empty and either diff is empty, return 100.0
-    if !intersect.empty() && (diff_ab.empty() || diff_ba.empty()) {
-        return args.score_cutoff.score(100.0);
-    }
-
-    // Join the differences
-    let diff_ab_joined = diff_ab.join();
-    let diff_ba_joined = diff_ba.join();
-
-    // Lengths
-    let ab_len = diff_ab_joined.len();
-    let ba_len = diff_ba_joined.len();
-    let sect_len = intersect.length();
-
-    let tokens_a_joined = tokens_a.join();
-    let tokens_b_joined = tokens_b.join();
-
-    // Placeholder for `ratio_with_args` function
-    // Ensure `ratio_with_args` is defined elsewhere in your library
-    let result = ratio_with_args(tokens_a_joined.clone(), tokens_b_joined.clone(), args);
-
-    let mut result_value = match result.into() {
-        Some(r) => r,
-        None => return args.score_cutoff.score(0.0),
-    };
-
-    let sect_len_bool = if sect_len > 0 { 1 } else { 0 };
-    let sect_ab_len = sect_len + sect_len_bool + ab_len;
-    let sect_ba_len = sect_len + sect_len_bool + ba_len;
-    let total_len = sect_ab_len + sect_ba_len;
-
-    let cutoff_distance = score_cutoff_to_distance(score_cutoff_value, total_len);
-
-    // Create distance args with the correct type
-    let dist_args = indel::Args::<usize, WithScoreCutoff<usize>> {
-        score_cutoff: WithScoreCutoff(cutoff_distance),
-        score_hint: None,
-    };
-
-    // Pass by reference to distance_with_args
-    let dist =
-        crate::distance::indel::distance_with_args(diff_ab_joined, diff_ba_joined, &dist_args);
-
-    if let Some(distance) = dist {
-        if distance <= cutoff_distance {
-            let norm_dist = norm_distance(distance, total_len, score_cutoff_value);
-            result_value = result_value.max(norm_dist);
-        }
-    }
-
-    if sect_len == 0 {
-        return args.score_cutoff.score(result_value);
-    }
-
-    let sect_ab_dist = sect_len_bool + ab_len;
-    let sect_ab_total_len = sect_len + sect_ab_len;
-    let sect_ab_ratio = norm_distance(sect_ab_dist, sect_ab_total_len, score_cutoff_value);
-
-    let sect_ba_dist = sect_len_bool + ba_len;
-    let sect_ba_total_len = sect_len + sect_ba_len;
-    let sect_ba_ratio = norm_distance(sect_ba_dist, sect_ba_total_len, score_cutoff_value);
-
-    result_value = result_value.max(sect_ab_ratio.max(sect_ba_ratio));
-    args.score_cutoff.score(result_value)
-}
-
-/// Computes the Partial Ratio between two sequences.
-///
-/// # Parameters
-/// - `s1`: The first sequence to compare.
-/// - `s2`: The second sequence to compare.
-/// - `score_cutoff`: The minimum score cutoff.
-///
-/// # Returns
-/// - The Partial Ratio between `s1` and `s2` as a `f64`.
-pub fn partial_ratio<Iter1, Iter2, CharT>(s1: Iter1, s2: Iter2, score_cutoff: f64) -> f64
-where
-    Iter1: IntoIterator<Item = CharT>,
-    Iter2: IntoIterator<Item = CharT>,
-    Iter1::IntoIter: Clone + DoubleEndedIterator<Item = CharT>,
-    Iter2::IntoIter: Clone + DoubleEndedIterator<Item = CharT>,
-    CharT: HashableChar + Clone + Ord + IsSpace + Copy,
-{
-    partial_ratio_with_args(s1, s2, &Args::default().score_cutoff(score_cutoff)).unwrap_or(0.0)
-}
-
-/// Computes the Partial Token Ratio between two sequences with additional arguments.
-///
-/// # Parameters
-/// - `s1_sorted`: The first sorted sequence.
-/// - `tokens_s1`: The splitted tokens of the first sequence.
-/// - `s2`: The second sequence to compare.
-/// - `args`: Additional arguments containing `score_cutoff` and `score_hint`.
-///
-/// # Returns
-/// - The Partial Token Ratio as defined by `CutoffType::Output`.
-pub fn partial_token_ratio_with_args<Iter2, CutoffType, CharT>(
-    s1_sorted: Vec<CharT>,
-    tokens_s1: SplittedSentence<CharT>,
-    s2: Iter2,
-    args: &Args<f64, CutoffType>,
-) -> CutoffType::Output
-where
-    Iter2: IntoIterator<Item = CharT>,
-    Iter2::IntoIter: Clone + DoubleEndedIterator<Item = CharT>,
-    CharT: HashableChar + Clone + Ord + IsSpace + Copy,
-    CutoffType: SimilarityCutoff<f64>,
-{
-    // Early exit if score_cutoff is greater than 100
-    let score_cutoff_value: f64 = args.score_cutoff.cutoff().unwrap_or(0.0);
-    if score_cutoff_value > 100.0 {
-        return args.score_cutoff.score(0.0);
-    }
-
-    // Split and sort tokens for the second sequence
-    let tokens_b = sorted_split(s2.into_iter());
-
-    // Decompose tokens into intersection and differences
-    let decomposition = set_decomposition(tokens_s1.clone(), tokens_b.clone());
-
-    // Exit early if there is a common word in both sequences
-    if !decomposition.intersection.empty() {
-        return args.score_cutoff.score(100.0);
-    }
-
-    let diff_ab = decomposition.difference_ab;
-    let diff_ba = decomposition.difference_ba;
-
-    // Compute the partial ratio between the joined differences
-    let result = partial_ratio(s1_sorted.clone(), tokens_b.join(), score_cutoff_value);
-
-    // Do not calculate the same partial_ratio twice
-    if tokens_s1.word_count() == diff_ab.word_count()
-        && tokens_b.word_count() == diff_ba.word_count()
-    {
-        return args.score_cutoff.score(result);
-    }
-
-    // Update score_cutoff to the maximum of current cutoff and result
-    let updated_score_cutoff = score_cutoff_value.max(result);
-
-    // Compute partial_ratio between the joined differences with updated cutoff
-    let additional_result = partial_ratio(diff_ab.join(), diff_ba.join(), updated_score_cutoff);
-
-    // Return the maximum of the two results
-    args.score_cutoff.score(result.max(additional_result))
-}
-
-/// Computes the Partial Token Ratio between two sequences.
-///
-/// # Parameters
-/// - `s1`: The first sequence to compare.
-/// - `s2`: The second sequence to compare.
-/// - `score_cutoff`: The minimum score cutoff.
-///
-/// # Returns
-/// - The Partial Token Ratio as a `f64`.
-///
-/// # Example
-/// ```
-/// use rapidfuzz::fuzz;
-///
-/// let s1 = "fuzzy wuzzy was a bear";
-/// let s2 = "wuzzy fuzzy was a hare";
-///
-/// let score = fuzz::partial_token_ratio(s1.chars(), s2.chars(), 80.0);
-/// assert!(score >= 80.0);
-/// ```
-pub fn partial_token_ratio<Iter1, Iter2, CharT>(s1: Iter1, s2: Iter2, score_cutoff: f64) -> f64
-where
-    Iter1: IntoIterator<Item = CharT> + Clone, // Added Clone
-    Iter2: IntoIterator<Item = CharT>,
-    Iter1::IntoIter: Clone + DoubleEndedIterator<Item = CharT>,
-    Iter2::IntoIter: Clone + DoubleEndedIterator<Item = CharT>,
-    CharT: HashableChar + Clone + Ord + IsSpace + Copy,
-{
-    let tokens_s1 = sorted_split(s1.clone());
-    let s1_sorted = tokens_s1.join();
-    partial_token_ratio_with_args(
-        s1_sorted,
-        tokens_s1,
-        s2,
-        &Args::default().score_cutoff(score_cutoff),
-    )
-    .unwrap_or(0.0)
-}
-
-/// Computes the Weighted Ratio (WRatio) between two sequences.
-///
-/// # Parameters
-/// - `s1`: The first sequence to compare.
-/// - `s2`: The second sequence to compare.
-/// - `args`: Additional arguments containing `score_cutoff` and `score_hint`.
-///
-/// # Returns
-/// - The Weighted Ratio between `s1` and `s2` or `0.0` if the computed ratio is below `score_cutoff`.
-///
-/// # Example
-/// ```
-/// use rapidfuzz::fuzz;
-///
-/// let s1 = "fuzzy wuzzy was a bear";
-/// let s2 = "wuzzy fuzzy was a bear";
-///
-/// let score = fuzz::wratio(s1.chars(), s2.chars(), 80.0);
-/// assert!(score >= 80.0);
-/// ```
-pub fn wratio_with_args<Iter1, Iter2, CutoffType, CharT>(
-    s1: Iter1,
-    s2: Iter2,
-    args: &Args<f64, CutoffType>,
-) -> CutoffType::Output
-where
-    // Both Iter1 and Iter2 must produce the same CharT
-    Iter1: IntoIterator<Item = CharT>,
-    Iter2: IntoIterator<Item = CharT>,
-
-    // Add bounds for both iterators
-    Iter1::IntoIter: Clone + DoubleEndedIterator<Item = CharT>,
-    Iter2::IntoIter: Clone + DoubleEndedIterator<Item = CharT>,
-
-    // Add all the required trait bounds for CharT
-    CharT: HashableChar + Clone + Ord + IsSpace + Copy,
-
-    CutoffType: SimilarityCutoff<f64> + Clone + Copy,
-{
-    // If the score cutoff is greater than 100, return the appropriate score.
-    if let Some(score_cutoff_value) = args.score_cutoff.cutoff() {
-        if score_cutoff_value > 100.0 {
-            return args.score_cutoff.score(0.0);
-        }
-    }
-
-    const UNBASE_SCALE: f64 = 0.95;
-
-    let s1_iter = s1.into_iter();
-    let s2_iter = s2.into_iter();
-
-    let len1 = s1_iter.clone().count();
-    let len2 = s2_iter.clone().count();
-
-    // For compatibility with FuzzyWuzzy, return `0.0` if either sequence is empty.
-    if len1 == 0 || len2 == 0 {
-        return args.score_cutoff.score(0.0);
-    }
-
-    // Calculate the length ratio.
-    let len_ratio = if len1 > len2 {
-        len1 as f64 / len2 as f64
-    } else {
-        len2 as f64 / len1 as f64
-    };
-
-    // Compute the initial ratio using the `ratio_with_args` function.
-    let end_ratio = ratio_with_args(s1_iter.clone(), s2_iter.clone(), args);
-
-    // Extract the end_ratio value or return early if `None`.
-    let mut end_ratio_value = match end_ratio.into() {
-        Some(r) => r,
-        None => return args.score_cutoff.score(0.0),
-    };
-
-    end_ratio_value = end_ratio_value * 100.00;
-
-    if len_ratio < 1.5 {
-        // Adjust the score cutoff based on UNBASE_SCALE.
-        let adjusted_cutoff =
-            f64::max(args.score_cutoff.cutoff().unwrap_or(0.0), end_ratio_value) / UNBASE_SCALE;
-
-        // Create new args with adjusted cutoff.
-        let cloned_args = args.clone();
-        let new_args = cloned_args.score_cutoff(adjusted_cutoff);
-
-        // Compute token_ratio using the adjusted cutoff.
-        let token_ratio_value = token_ratio_with_args(s1_iter.clone(), s2_iter.clone(), &new_args);
-
-        // Multiply by UNBASE_SCALE and update the final score.
-        let scaled_token_ratio = match token_ratio_value {
-            Some(r) => r * UNBASE_SCALE,
-            None => end_ratio_value, // If token_ratio is None, retain end_ratio_value.
-        };
-
-        // Update end_ratio_value with the maximum of end_ratio and scaled_token_ratio.
-        end_ratio_value = f64::max(end_ratio_value, scaled_token_ratio);
-        return args.score_cutoff.score(end_ratio_value);
-    }
-
-    // Determine the partial scaling factor based on the length ratio.
-    let partial_scale = if len_ratio < 8.0 { 0.9 } else { 0.6 };
-
-    // Adjust score_cutoff based on PARTIAL_SCALE.
-    let adjusted_cutoff =
-        f64::max(args.score_cutoff.cutoff().unwrap_or(0.0), end_ratio_value) / partial_scale;
-
-    // Create new args with adjusted cutoff.
-    let new_args = args.clone().score_cutoff(adjusted_cutoff);
-
-    // Compute partial_ratio using the adjusted cutoff.
-    let partial_ratio_value = partial_ratio_with_args(s1_iter.clone(), s2_iter.clone(), &new_args);
-
-    // Update end_ratio_value with the maximum value.
-    if let Some(partial_ratio_result) = partial_ratio_value {
-        let scaled_partial_ratio = partial_ratio_result * partial_scale;
-        end_ratio_value = f64::max(end_ratio_value, scaled_partial_ratio);
-    }
-
-    // Adjust score_cutoff again based on UNBASE_SCALE.
-    let final_cutoff =
-        f64::max(args.score_cutoff.cutoff().unwrap_or(0.0), end_ratio_value) / UNBASE_SCALE;
-
-    // Create new args with adjusted cutoff.
-    let new_args = args.clone().score_cutoff(final_cutoff);
-
-    // Split and sort tokens from the first sequence for partial_token_ratio_with_args
-    let tokens_a = sorted_split(s1_iter.clone());
-    let s1_sorted = tokens_a.join();
-
-    // Compute partial_token_ratio using the adjusted cutoff.
-    let partial_token_ratio_value =
-        partial_token_ratio_with_args(s1_sorted, tokens_a.clone(), s2_iter.clone(), &new_args);
-
-    // Update end_ratio_value with the maximum value.
-    if let Some(partial_token_ratio_result) = partial_token_ratio_value {
-        let scaled_partial_token_ratio = partial_token_ratio_result * UNBASE_SCALE * partial_scale;
-        end_ratio_value = f64::max(end_ratio_value, scaled_partial_token_ratio);
-    }
-
-    // Return the final end_ratio_value using the `score` method.
-    args.score_cutoff.score(end_ratio_value)
-}
-
-/// Computes the Weighted Ratio (WRatio) between two sequences.
-///
-/// This is a convenience function that uses default arguments.
-///
-/// # Parameters
-/// - `s1`: The first sequence to compare.
-/// - `s2`: The second sequence to compare.
-///
-/// # Returns
-/// - The Weighted Ratio between `s1` and `s2` as a `f64`.
-///
-/// # Example
-/// ```
-/// use rapidfuzz::fuzz::wratio;
-///
-/// let s1 = "fuzzy wuzzy was a bear";
-/// let s2 = "wuzzy fuzzy was a bear";
-///
-/// let score = wratio(s1.chars(), s2.chars(), 0.0);
-/// assert_eq!(score, 100.0);
-/// ```
-pub fn wratio<Iter1, Iter2, CharT>(s1: Iter1, s2: Iter2, score_cutoff: f64) -> f64
-where
-    Iter1: IntoIterator<Item = CharT>,
-    Iter2: IntoIterator<Item = CharT>,
-
-    Iter1::IntoIter: Clone + DoubleEndedIterator<Item = CharT>,
-    Iter2::IntoIter: Clone + DoubleEndedIterator<Item = CharT>,
-
-    CharT: HashableChar + Clone + Ord + IsSpace + Copy,
-{
-    wratio_with_args(s1, s2, &Args::default().score_cutoff(score_cutoff)).unwrap_or(0.0)
 }
 
 #[must_use]
@@ -573,15 +59,7 @@ impl<ResultType, CutoffType> Args<ResultType, CutoffType> {
     }
 }
 
-/// Returns a simple ratio between two strings or `None` if `ratio < score_cutoff`
-///
-/// # Example
-/// ```
-/// use rapidfuzz::fuzz;
-/// /// score is 0.9655
-/// let score = fuzz::ratio("this is a test".chars(), "this is a test!".chars());
-/// ```
-///
+/// Returns a simple ratio between two strings
 pub fn ratio<Iter1, Iter2>(s1: Iter1, s2: Iter2) -> f64
 where
     Iter1: IntoIterator,
@@ -622,16 +100,6 @@ where
 }
 
 /// `One x Many` comparisons using `ratio`
-///
-/// # Examples
-///
-/// ```
-/// use rapidfuzz::fuzz;
-///
-/// let scorer = fuzz::RatioBatchComparator::new("this is a test".chars());
-/// /// score is 0.9655
-/// let score = scorer.similarity("this is a test!".chars());
-/// ```
 pub struct RatioBatchComparator<Elem1> {
     scorer: indel::BatchComparator<Elem1>,
 }
@@ -650,7 +118,6 @@ where
         }
     }
 
-    /// Similarity calculated similar to [`ratio`]
     pub fn similarity<Iter2>(&self, s2: Iter2) -> f64
     where
         Iter2: IntoIterator,
@@ -686,968 +153,705 @@ where
     }
 }
 
+/// Searches for the optimal alignment of the shorter string in the longer string
+/// and returns the `fuzz::ratio` score for this alignment.
+pub fn partial_ratio<Iter1, Iter2>(s1: Iter1, s2: Iter2, score_cutoff: f64) -> f64
+where
+    Iter1: IntoIterator,
+    Iter1::IntoIter: DoubleEndedIterator + Clone,
+    Iter2: IntoIterator,
+    Iter2::IntoIter: DoubleEndedIterator + Clone,
+    Iter1::Item: PartialEq<Iter2::Item> + HashableChar + Copy,
+    Iter2::Item: PartialEq<Iter1::Item> + HashableChar + Copy,
+{
+    partial_ratio_with_args(s1, s2, &Args::default().score_cutoff(score_cutoff)).unwrap_or(0.0)
+}
+
+pub fn partial_ratio_with_args<Iter1, Iter2, CutoffType>(
+    s1: Iter1,
+    s2: Iter2,
+    args: &Args<f64, CutoffType>,
+) -> CutoffType::Output
+where
+    Iter1: IntoIterator,
+    Iter1::IntoIter: DoubleEndedIterator + Clone,
+    Iter2: IntoIterator,
+    Iter2::IntoIter: DoubleEndedIterator + Clone,
+    Iter1::Item: PartialEq<Iter2::Item> + HashableChar + Copy,
+    Iter2::Item: PartialEq<Iter1::Item> + HashableChar + Copy,
+    CutoffType: SimilarityCutoff<f64>,
+{
+    let s1_iter = s1.into_iter();
+    let s2_iter = s2.into_iter();
+
+    let alignment = partial_ratio_alignment(
+        s1_iter.clone(),
+        s1_iter.count(),
+        s2_iter.clone(),
+        s2_iter.count(),
+        args,
+    );
+
+    let score = alignment.into().map_or(0.0, |a| a.score);
+    args.score_cutoff.score(score)
+}
+
+pub fn partial_ratio_alignment<Iter1, Iter2, CutoffType>(
+    s1: Iter1,
+    len1: usize,
+    s2: Iter2,
+    len2: usize,
+    args: &Args<f64, CutoffType>,
+) -> CutoffType::AlignmentOutput
+where
+    Iter1: IntoIterator,
+    Iter1::IntoIter: DoubleEndedIterator + Clone,
+    Iter2: IntoIterator,
+    Iter2::IntoIter: DoubleEndedIterator + Clone,
+    Iter1::Item: PartialEq<Iter2::Item> + HashableChar + Copy,
+    Iter2::Item: PartialEq<Iter1::Item> + HashableChar + Copy,
+    CutoffType: SimilarityCutoff<f64>,
+{
+    let s1_iter = s1.into_iter();
+    let s2_iter = s2.into_iter();
+    let mut score_cutoff = args.score_cutoff.cutoff().unwrap_or(0.0);
+
+    if score_cutoff > 1.0 {
+        return args.score_cutoff.alignment(None);
+    }
+
+    if len1 > len2 {
+        let res = partial_ratio_alignment(s2_iter.clone(), len2, s1_iter.clone(), len1, args);
+        return args.score_cutoff.alignment(res.into().map(|mut alignment| {
+            std::mem::swap(&mut alignment.src_start, &mut alignment.dest_start);
+            std::mem::swap(&mut alignment.src_end, &mut alignment.dest_end);
+            alignment
+        }));
+    }
+
+    if len1 == 0 || len2 == 0 {
+        return args.score_cutoff.alignment(Some(ScoreAlignment {
+            score: f64::from(len1 == len2),
+            src_start: 0,
+            src_end: len1,
+            dest_start: 0,
+            dest_end: len1,
+        }));
+    }
+
+    let s1_char_set = s1_iter
+        .clone()
+        .map(|c| c.hash_char())
+        .collect::<HashSet<Hash>>();
+
+    let indel_comp = indel::BatchComparator::new(s1_iter.clone());
+
+    let mut res = partial_ratio_impl(
+        &indel_comp,
+        len1,
+        s2_iter.clone(),
+        len2,
+        &s1_char_set,
+        score_cutoff,
+        args.score_hint,
+    );
+
+    if (res.score != 1.0) && (len1 == len2) {
+        score_cutoff = f64::max(score_cutoff, res.score);
+        let indel_comp = indel::BatchComparator::new(s2_iter.clone());
+        let res2 = partial_ratio_impl(
+            &indel_comp,
+            len2,
+            s1_iter.clone(),
+            len1,
+            &s1_char_set,
+            score_cutoff,
+            args.score_hint,
+        );
+        if res2.score > res.score {
+            res = ScoreAlignment {
+                score: res2.score,
+                src_start: res2.dest_start,
+                src_end: res2.dest_end,
+                dest_start: res2.src_start,
+                dest_end: res2.src_end,
+            };
+        }
+    }
+
+    let alignment = if res.score < score_cutoff {
+        None
+    } else {
+        Some(res)
+    };
+
+    args.score_cutoff.alignment(alignment)
+}
+
+/*
+implementation of partial_ratio for len(s1) <= len(s2)
+*/
+fn partial_ratio_impl<Elem1, Iter2>(
+    comparator: &indel::BatchComparator<Elem1>,
+    len1: usize,
+    s2: Iter2,
+    len2: usize,
+    s1_char_set: &HashSet<Hash>,
+    mut score_cutoff: f64,
+    score_hint: Option<f64>,
+) -> ScoreAlignment
+where
+    Iter2: IntoIterator,
+    Iter2::IntoIter: DoubleEndedIterator + Clone,
+    Elem1: PartialEq<Iter2::Item> + HashableChar + Copy,
+    Iter2::Item: PartialEq<Elem1> + HashableChar + Copy,
+{
+    if len1 == 0 {
+        return ScoreAlignment {
+            score: 0.0,
+            src_start: 0,
+            src_end: 0,
+            dest_start: 0,
+            dest_end: 0,
+        };
+    }
+
+    let s2_vec = s2.into_iter().collect::<Vec<_>>();
+
+    let mut res = ScoreAlignment {
+        score: 0.0,
+        src_start: 0,
+        src_end: len1,
+        dest_start: 0,
+        dest_end: len1,
+    };
+
+    let len_sum = 2 * len1;
+    let mut cutoff_dist = ((len_sum as f64) * (1.0 - score_cutoff)).ceil() as usize;
+
+    for i in 1..len1 {
+        let substr_last = &s2_vec[i - 1];
+        if !s1_char_set.contains(&substr_last.hash_char()) {
+            continue;
+        }
+
+        let ls_ratio = comparator
+            .normalized_similarity_with_args(
+                s2_vec[..i].iter().cloned(),
+                &indel::Args {
+                    score_cutoff: WithScoreCutoff(score_cutoff),
+                    score_hint,
+                },
+            )
+            .unwrap_or(0.0);
+        if ls_ratio > res.score {
+            score_cutoff = ls_ratio;
+            cutoff_dist = ((len_sum as f64) * (1.0 - score_cutoff)).ceil() as usize;
+            res.score = ls_ratio;
+            res.dest_start = 0;
+            res.dest_end = i;
+            if res.score == 1.0 {
+                return res;
+            }
+        }
+    }
+
+    let window_end = len2 - len1;
+    let mut scores = vec![usize::MAX; window_end + 1];
+    let mut windows = vec![(0, window_end)];
+    let mut new_windows = Vec::new();
+    let mut best_dist = ((len_sum as f64) * (1.0 - res.score)).ceil() as usize;
+
+    while !windows.is_empty() {
+        for (start, end) in windows.drain(..) {
+            if scores[start] == usize::MAX {
+                let subseq = &s2_vec[start..start + len1];
+                let dist = comparator.distance(subseq.iter().cloned());
+                scores[start] = dist;
+
+                if dist < best_dist {
+                    best_dist = dist;
+                    cutoff_dist = dist;
+                    res.score = 1.0 - (dist as f64 / len_sum as f64);
+                    res.dest_start = start;
+                    res.dest_end = start + len1;
+                    score_cutoff = res.score;
+                    if dist == 0 {
+                        return res;
+                    }
+                }
+            }
+
+            if scores[end] == usize::MAX {
+                let subseq = &s2_vec[end..end + len1];
+                let dist = comparator.distance(subseq.iter().cloned());
+                scores[end] = dist;
+
+                if dist < best_dist {
+                    best_dist = dist;
+                    cutoff_dist = dist;
+                    res.score = 1.0 - (dist as f64 / len_sum as f64);
+                    res.dest_start = end;
+                    res.dest_end = end + len1;
+                    score_cutoff = res.score;
+                    if dist == 0 {
+                        return res;
+                    }
+                }
+            }
+
+            let cell_diff = end - start;
+            if cell_diff <= 1 {
+                continue;
+            }
+
+            let score_start = scores[start];
+            let score_end = scores[end];
+
+            let min_val = score_start.min(score_end);
+            let known_edits = score_start.abs_diff(score_end);
+
+            // half of the cells that are not needed for known_edits can lead to a better score
+            let max_score_improvement = (cell_diff.saturating_sub(known_edits / 2) / 2) * 2;
+            if min_val > cutoff_dist.saturating_add(max_score_improvement) {
+                continue;
+            }
+
+            let center = cell_diff / 2;
+            new_windows.push((start, start + center));
+            new_windows.push((start + center, end));
+        }
+        std::mem::swap(&mut windows, &mut new_windows);
+    }
+
+    for i in window_end + 1..len2 {
+        let substr_first = &s2_vec[i];
+        if !s1_char_set.contains(&substr_first.hash_char()) {
+            continue;
+        }
+
+        let ls_ratio = comparator
+            .normalized_similarity_with_args(
+                s2_vec[i..].iter().cloned(),
+                &indel::Args {
+                    score_cutoff: WithScoreCutoff(score_cutoff),
+                    score_hint,
+                },
+            )
+            .unwrap_or(0.0);
+
+        if ls_ratio > res.score {
+            score_cutoff = ls_ratio;
+            res.score = ls_ratio;
+            res.dest_start = i;
+            res.dest_end = len2;
+            if res.score == 1.0 {
+                return res;
+            }
+        }
+    }
+
+    res
+}
+
+/// `One x Many` comparisons using `partial_ratio`
+pub struct PartialRatioBatchComparator<Elem1> {
+    scorer: indel::BatchComparator<Elem1>,
+    s1_char_set: HashSet<Hash>,
+}
+
+impl<Elem1> PartialRatioBatchComparator<Elem1>
+where
+    Elem1: HashableChar + Clone,
+{
+    pub fn new<Iter1>(s1: Iter1) -> Self
+    where
+        Iter1: IntoIterator<Item = Elem1>,
+        Iter1::IntoIter: Clone,
+    {
+        let scorer = indel::BatchComparator::new(s1);
+        let s1_char_set = scorer
+            .scorer
+            .s1
+            .iter()
+            .map(|c| c.hash_char())
+            .collect::<HashSet<Hash>>();
+        Self {
+            scorer,
+            s1_char_set,
+        }
+    }
+
+    pub fn similarity<Iter2>(&self, s2: Iter2) -> f64
+    where
+        Iter2: IntoIterator,
+        Iter2::IntoIter: DoubleEndedIterator + Clone,
+        Elem1: PartialEq<Iter2::Item> + HashableChar + Copy,
+        Iter2::Item: PartialEq<Elem1> + HashableChar + Copy,
+    {
+        self.similarity_with_args(s2, &Args::default())
+    }
+
+    pub fn similarity_with_args<Iter2, CutoffType>(
+        &self,
+        s2: Iter2,
+        args: &Args<f64, CutoffType>,
+    ) -> CutoffType::Output
+    where
+        Iter2: IntoIterator,
+        Iter2::IntoIter: DoubleEndedIterator + Clone,
+        Elem1: PartialEq<Iter2::Item> + HashableChar + Copy,
+        Iter2::Item: PartialEq<Elem1> + HashableChar + Copy,
+        CutoffType: SimilarityCutoff<f64>,
+    {
+        let s2_iter = s2.into_iter();
+        let len1 = self.scorer.scorer.s1.len();
+        let len2 = s2_iter.clone().count();
+
+        let score = if len1 <= len2 {
+            partial_ratio_impl(
+                &self.scorer,
+                len1,
+                s2_iter.clone(),
+                len2,
+                &self.s1_char_set,
+                args.score_cutoff.cutoff().unwrap_or(0.0),
+                args.score_hint,
+            )
+            .score
+        } else {
+            partial_ratio_with_args(self.scorer.scorer.s1.iter().copied(), s2_iter, args)
+                .into()
+                .unwrap_or(0.0)
+        };
+
+        args.score_cutoff.score(score)
+    }
+}
+
+/// Computes the token ratio between two sequences.
+pub fn token_ratio_with_args<Iter1, Iter2, CutoffType, CharT>(
+    s1: Iter1,
+    s2: Iter2,
+    args: &Args<f64, CutoffType>,
+) -> CutoffType::Output
+where
+    Iter1: IntoIterator<Item = CharT>,
+    Iter2: IntoIterator<Item = CharT>,
+    Iter1::IntoIter: Clone + DoubleEndedIterator<Item = CharT>,
+    Iter2::IntoIter: Clone + DoubleEndedIterator<Item = CharT>,
+    CharT: HashableChar + Clone + Ord + IsSpace + Copy,
+    CutoffType: SimilarityCutoff<f64>,
+{
+    let score_cutoff = args.score_cutoff.cutoff().unwrap_or(0.0);
+
+    if score_cutoff > 1.0 {
+        return args.score_cutoff.score(0.0);
+    }
+
+    let tokens_a = sorted_split(s1);
+    let tokens_b = sorted_split(s2);
+
+    let decomposition = set_decomposition(tokens_a.clone(), tokens_b.clone());
+    let intersect = decomposition.intersection;
+    let diff_ab = decomposition.difference_ab;
+    let diff_ba = decomposition.difference_ba;
+
+    if !intersect.empty() && (diff_ab.empty() || diff_ba.empty()) {
+        return args.score_cutoff.score(1.0);
+    }
+
+    let diff_ab_joined = diff_ab.join();
+    let diff_ba_joined = diff_ba.join();
+
+    let ab_len = diff_ab_joined.len();
+    let ba_len = diff_ba_joined.len();
+    let sect_len = intersect.length();
+
+    let mut result = ratio_with_args(tokens_a.join(), tokens_b.join(), args)
+        .into()
+        .unwrap_or(0.0);
+
+    let sect_ab_len = sect_len + usize::from(sect_len > 0) + ab_len;
+    let sect_ba_len = sect_len + usize::from(sect_len > 0) + ba_len;
+    let total_len = sect_ab_len + sect_ba_len;
+
+    let cutoff_distance = score_cutoff_to_distance(score_cutoff, total_len);
+    let dist_args = indel::Args::<usize, WithScoreCutoff<usize>> {
+        score_cutoff: WithScoreCutoff(cutoff_distance),
+        score_hint: None,
+    };
+
+    if let Some(distance) = indel::distance_with_args(diff_ab_joined, diff_ba_joined, &dist_args) {
+        result = result.max(norm_distance(distance, total_len, score_cutoff));
+    }
+
+    if sect_len == 0 {
+        return args.score_cutoff.score(result);
+    }
+
+    let sect_ab_dist = usize::from(sect_len > 0) + ab_len;
+    let sect_ba_dist = usize::from(sect_len > 0) + ba_len;
+
+    let sect_ab_ratio = norm_distance(sect_ab_dist, sect_len + sect_ab_len, score_cutoff);
+    let sect_ba_ratio = norm_distance(sect_ba_dist, sect_len + sect_ba_len, score_cutoff);
+
+    args.score_cutoff
+        .score(result.max(sect_ab_ratio.max(sect_ba_ratio)))
+}
+
+/// Computes the partial token ratio between two sequences.
+pub fn partial_token_ratio_with_args<Iter2, CutoffType, CharT>(
+    s1_sorted: Vec<CharT>,
+    tokens_s1: SplittedSentence<CharT>,
+    s2: Iter2,
+    args: &Args<f64, CutoffType>,
+) -> CutoffType::Output
+where
+    Iter2: IntoIterator<Item = CharT>,
+    Iter2::IntoIter: Clone + DoubleEndedIterator<Item = CharT>,
+    CharT: HashableChar + Clone + Ord + IsSpace + Copy,
+    CutoffType: SimilarityCutoff<f64>,
+{
+    let score_cutoff = args.score_cutoff.cutoff().unwrap_or(0.0);
+    if score_cutoff > 1.0 {
+        return args.score_cutoff.score(0.0);
+    }
+
+    let tokens_b = sorted_split(s2);
+    let decomposition = set_decomposition(tokens_s1.clone(), tokens_b.clone());
+
+    // exit early when there is a common word in both sequences
+    if !decomposition.intersection.empty() {
+        return args.score_cutoff.score(1.0);
+    }
+
+    let diff_ab = decomposition.difference_ab;
+    let diff_ba = decomposition.difference_ba;
+
+    let result = partial_ratio(s1_sorted.clone(), tokens_b.join(), score_cutoff);
+
+    // do not calculate the same partial_ratio twice
+    if tokens_s1.word_count() == diff_ab.word_count()
+        && tokens_b.word_count() == diff_ba.word_count()
+    {
+        return args.score_cutoff.score(result);
+    }
+
+    let updated_score_cutoff = score_cutoff.max(result);
+    let additional_result = partial_ratio(diff_ab.join(), diff_ba.join(), updated_score_cutoff);
+
+    args.score_cutoff.score(result.max(additional_result))
+}
+
+pub fn partial_token_ratio<Iter1, Iter2, CharT>(s1: Iter1, s2: Iter2, score_cutoff: f64) -> f64
+where
+    Iter1: IntoIterator<Item = CharT> + Clone,
+    Iter2: IntoIterator<Item = CharT>,
+    Iter1::IntoIter: Clone + DoubleEndedIterator<Item = CharT>,
+    Iter2::IntoIter: Clone + DoubleEndedIterator<Item = CharT>,
+    CharT: HashableChar + Clone + Ord + IsSpace + Copy,
+{
+    let tokens_s1 = sorted_split(s1.clone());
+    let s1_sorted = tokens_s1.join();
+    partial_token_ratio_with_args(
+        s1_sorted,
+        tokens_s1,
+        s2,
+        &Args::default().score_cutoff(score_cutoff),
+    )
+    .unwrap_or(0.0)
+}
+
+/// Computes the weighted ratio between two sequences.
+pub fn wratio_with_args<Iter1, Iter2, CutoffType, CharT>(
+    s1: Iter1,
+    s2: Iter2,
+    args: &Args<f64, CutoffType>,
+) -> CutoffType::Output
+where
+    Iter1: IntoIterator<Item = CharT>,
+    Iter2: IntoIterator<Item = CharT>,
+    Iter1::IntoIter: Clone + DoubleEndedIterator<Item = CharT>,
+    Iter2::IntoIter: Clone + DoubleEndedIterator<Item = CharT>,
+    CharT: HashableChar + Clone + Ord + IsSpace + Copy,
+    CutoffType: SimilarityCutoff<f64> + Clone + Copy,
+{
+    const UNBASE_SCALE: f64 = 0.95;
+
+    let initial_cutoff = args.score_cutoff.cutoff().unwrap_or(0.0);
+    if initial_cutoff > 1.0 {
+        return args.score_cutoff.score(0.0);
+    }
+
+    let s1_iter = s1.into_iter();
+    let s2_iter = s2.into_iter();
+
+    let len1 = s1_iter.clone().count();
+    let len2 = s2_iter.clone().count();
+
+    // compatibility with fuzzywuzzy
+    if len1 == 0 || len2 == 0 {
+        return args.score_cutoff.score(0.0);
+    }
+
+    let len_ratio = if len1 > len2 {
+        len1 as f64 / len2 as f64
+    } else {
+        len2 as f64 / len1 as f64
+    };
+
+    let mut end_ratio = ratio_with_args(s1_iter.clone(), s2_iter.clone(), args)
+        .into()
+        .unwrap_or(0.0);
+
+    if len_ratio < 1.5 {
+        let adjusted_cutoff = initial_cutoff.max(end_ratio) / UNBASE_SCALE;
+        let new_args = args.clone().score_cutoff(adjusted_cutoff);
+        let token_ratio_raw: Option<f64> =
+            token_ratio_with_args(s1_iter.clone(), s2_iter.clone(), &new_args);
+        let token_ratio_score = token_ratio_raw.unwrap_or(0.0);
+        end_ratio = end_ratio.max(token_ratio_score * UNBASE_SCALE);
+        return args.score_cutoff.score(end_ratio);
+    }
+
+    let partial_scale = if len_ratio <= 8.0 { 0.9 } else { 0.6 };
+
+    let adjusted_cutoff = initial_cutoff.max(end_ratio) / partial_scale;
+    let new_args = args.clone().score_cutoff(adjusted_cutoff);
+    let partial_ratio_raw: Option<f64> =
+        partial_ratio_with_args(s1_iter.clone(), s2_iter.clone(), &new_args);
+    let partial_ratio_score = partial_ratio_raw.unwrap_or(0.0);
+    end_ratio = end_ratio.max(partial_ratio_score * partial_scale);
+
+    let final_cutoff = initial_cutoff.max(end_ratio) / UNBASE_SCALE;
+    let new_args = args.clone().score_cutoff(final_cutoff);
+
+    let tokens_a = sorted_split(s1_iter.clone());
+    let s1_sorted = tokens_a.join();
+
+    let partial_token_ratio_raw: Option<f64> =
+        partial_token_ratio_with_args(s1_sorted, tokens_a, s2_iter, &new_args);
+    let partial_token_ratio_score = partial_token_ratio_raw.unwrap_or(0.0);
+
+    end_ratio = end_ratio.max(partial_token_ratio_score * UNBASE_SCALE * partial_scale);
+
+    args.score_cutoff.score(end_ratio)
+}
+
+pub fn wratio<Iter1, Iter2, CharT>(s1: Iter1, s2: Iter2, score_cutoff: f64) -> f64
+where
+    Iter1: IntoIterator<Item = CharT>,
+    Iter2: IntoIterator<Item = CharT>,
+    Iter1::IntoIter: Clone + DoubleEndedIterator<Item = CharT>,
+    Iter2::IntoIter: Clone + DoubleEndedIterator<Item = CharT>,
+    CharT: HashableChar + Clone + Ord + IsSpace + Copy,
+{
+    wratio_with_args(s1, s2, &Args::default().score_cutoff(score_cutoff)).unwrap_or(0.0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    static S1: &str = "new york mets";
-    static S3: &str = "the wonderful new york mets";
-    //static S4: &str = "new york mets vs atlanta braves";
-    //static S5: &str = "atlanta braves vs new york mets";
-    //static S7: &str = "new york city mets - atlanta braves";
-    // test silly corner cases
-    static S8: &str = "{";
-    static S9: &str = "{a";
-    //static S10: &str = "a{";
-    //static S10A: &str = "{b";
-
     macro_rules! assert_delta {
         ($x:expr, $y:expr) => {
-            match ($x, $y) {
-                (None, None) => {}
-                (Some(val1), Some(val2)) => {
-                    if (val1 - val2).abs() > 0.0001 {
-                        panic!("{:?} != {:?}", $x, $y);
-                    }
-                }
-                (_, _) => panic!("{:?} != {:?}", $x, $y),
-            }
+            assert!(($x - $y).abs() < 0.0001, "{} != {}", $x, $y);
         };
     }
 
     #[test]
-    fn test_equal() {
-        assert_delta!(
-            Some(1.0),
-            Some(ratio_with_args(S1.chars(), S1.chars(), &Args::default()))
-        );
-        assert_delta!(
-            Some(1.0),
-            Some(ratio_with_args(
-                "test".chars(),
-                "test".chars(),
-                &Args::default()
-            ))
-        );
-        assert_delta!(
-            Some(1.0),
-            Some(ratio_with_args(S8.chars(), S8.chars(), &Args::default()))
-        );
-        assert_delta!(
-            Some(1.0),
-            Some(ratio_with_args(S9.chars(), S9.chars(), &Args::default()))
-        );
-    }
-
-    #[test]
-    fn test_partial_ratio() {
-        //assert_delta!(Some(1.0), partial_ratio(S1.chars(), S1.chars(), None, None));
-        assert_delta!(
-            Some(0.65),
-            Some(ratio_with_args(S1.chars(), S3.chars(), &Args::default()))
-        );
-        //assert_delta!(Some(1.0), partial_ratio(S1.chars(), S3.chars(), None, None));
-    }
-
-    #[test]
-    fn two_empty_strings() {
-        assert_delta!(
-            Some(1.0),
-            Some(ratio_with_args("".chars(), "".chars(), &Args::default()))
-        );
-    }
-
-    #[test]
-    fn first_string_empty() {
-        assert_delta!(
-            Some(0.0),
-            Some(ratio_with_args(
-                "test".chars(),
-                "".chars(),
-                &Args::default()
-            ))
-        );
-    }
-
-    #[test]
-    fn second_string_empty() {
-        assert_delta!(
-            Some(0.0),
-            Some(ratio_with_args(
-                "".chars(),
-                "test".chars(),
-                &Args::default()
-            ))
-        );
+    fn ratio_basics() {
+        assert_delta!(1.0, ratio("test".chars(), "test".chars()));
+        assert_delta!(0.0, ratio("".chars(), "test".chars()));
+        assert_delta!(1.0, ratio("".chars(), "".chars()));
     }
 
     // https://github.com/rapidfuzz/RapidFuzz/issues/206
     #[test]
-    fn issue206() {
+    fn issue206_ratio_cutoff() {
         let str1 = "South Korea";
         let str2 = "North Korea";
+        let score = ratio(str1.chars(), str2.chars());
 
-        {
-            let score = ratio(str1.chars(), str2.chars());
-
-            assert_eq!(
-                None,
-                ratio_with_args(
-                    str1.chars(),
-                    str2.chars(),
-                    &Args::default().score_cutoff(score + 0.0001)
-                )
-            );
-            assert_delta!(
-                Some(score),
-                ratio_with_args(
-                    str1.chars(),
-                    str2.chars(),
-                    &Args::default().score_cutoff(score - 0.0001)
-                )
-            );
-        }
-    }
-
-    // https://github.com/rapidfuzz/RapidFuzz/issues/210
-    #[test]
-    fn issue210() {
-        let str1 = "bc";
-        let str2 = "bca";
-
-        {
-            let score = ratio(str1.chars(), str2.chars());
-
-            assert_eq!(
-                None,
-                ratio_with_args(
-                    str1.chars(),
-                    str2.chars(),
-                    &Args::default().score_cutoff(score + 0.0001)
-                )
-            );
-            assert_delta!(
-                Some(score),
-                ratio_with_args(
-                    str1.chars(),
-                    str2.chars(),
-                    &Args::default().score_cutoff(score - 0.0001)
-                )
-            );
-        }
-    }
-
-    // ---------------------- Additional Tests Start Here ----------------------
-
-    // 1. Additional Tests for `ratio_with_args`
-    #[test]
-    fn test_ratio_with_args_identical_strings() {
-        let s1 = "hello world";
-        let s2 = "hello world";
-        let args = Args::default();
-        let score = ratio_with_args(s1.chars(), s2.chars(), &args) * 100.00;
-        assert_eq!(score, 100.0);
-    }
-
-    #[test]
-    fn test_ratio_with_args_completely_different_strings() {
-        let s1 = "abcdefg";
-        let s2 = "hijklmn";
-        let args = Args::default();
-        let score = ratio_with_args(s1.chars(), s2.chars(), &args) * 100.00;
-        assert_eq!(score, 0.0);
-    }
-
-    #[test]
-    fn test_ratio_with_args_partial_overlap() {
-        let s1 = "hello world";
-        let s2 = "hello there";
-        let args = Args::default();
-        let score = ratio_with_args(s1.chars(), s2.chars(), &args) * 100.00;
-        assert!(score > 50.0 && score < 100.0); // Adjust based on actual expected score
-    }
-
-    #[test]
-    fn test_ratio_with_args_case_sensitive() {
-        let s1 = "Hello World";
-        let s2 = "hello world";
-        let args = Args::default();
-        let score = ratio_with_args(s1.chars(), s2.chars(), &args) * 100.00;
-        assert!(score < 100.0);
-    }
-
-    #[test]
-    fn test_ratio_with_args_unicode_characters() {
-        let s1 = "こんにちは世界"; // "Hello World" in Japanese
-        let s2 = "こんにちは世界";
-        let args = Args::default();
-        let score = ratio_with_args(s1.chars(), s2.chars(), &args) * 100.00;
-        assert_eq!(score, 100.0);
-    }
-
-    // 2. Additional Tests for `partial_ratio_with_args`
-    #[test]
-    fn test_partial_ratio_with_args_one_substring() {
-        let s1 = "hello";
-        let s2 = "hello world";
-        let args = Args::default();
-        let score = partial_ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert_eq!(score, 100.0); // Perfect match within the partial window
-    }
-
-    #[test]
-    fn test_partial_ratio_with_args_partial_match() {
-        let s1 = "abcdxyz";
-        let s2 = "xyzabcd";
-        let args = Args::default();
-        let score = partial_ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert!(score > 50.0 && score < 100.0); // Adjust based on actual expected score
-    }
-
-    #[test]
-    fn test_partial_ratio_with_args_no_overlap() {
-        let s1 = "abcdef";
-        let s2 = "uvwxyz";
-        let args = Args::default();
-        let score = partial_ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert_eq!(score, 0.0);
-    }
-
-    #[test]
-    fn test_partial_ratio_with_args_empty_string() {
-        let s1 = "";
-        let s2 = "hello";
-        let args = Args::default();
-        let score = partial_ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert_eq!(score, 0.0);
-    }
-
-    // 3. Additional Tests for `token_ratio_with_args`
-    #[test]
-    fn test_token_ratio_with_args_same_tokens_different_order() {
-        let s1 = "quick brown fox";
-        let s2 = "brown quick fox";
-        let args = Args::default();
-        let score = token_ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert_eq!(score, 100.0); // Tokens match despite order
-    }
-
-    #[test]
-    fn test_token_ratio_with_args_partial_tokens() {
-        let s1 = "quick brown fox jumps";
-        let s2 = "quick fox";
-        let args = Args::default();
-        let score = token_ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert!(score == 100.0); // Adjust based on expected partial token ratio
-    }
-
-    #[test]
-    fn test_token_ratio_with_args_no_common_tokens() {
-        let s1 = "abc def ghi";
-        let s2 = "jkl mno pqr";
-        let args = Args::default();
-        let score = token_ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert_eq!(score, 18.181818181818187);
-    }
-
-    #[test]
-    fn test_token_ratio_with_args_case_insensitive() {
-        let s1 = "Quick Brown Fox";
-        let s2 = "quick brown fox";
-        let args = Args::default();
-        let score = token_ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert!(score >= 100.0 || score < 100.0); // Placeholder
-    }
-
-    // 4. Additional Tests for `partial_token_ratio_with_args`
-    #[test]
-    fn test_partial_token_ratio_with_args_partial_token_match() {
-        let s1 = "fuzzy wuzzy was a bear";
-        let s2 = "wuzzy fuzzy was a hare";
-        let args = Args::default();
-        let score = partial_token_ratio_with_args(
-            s1.chars().collect::<Vec<_>>(),
-            sorted_split(s1.chars()),
-            s2.chars(),
-            &args,
+        assert_eq!(
+            None,
+            ratio_with_args(
+                str1.chars(),
+                str2.chars(),
+                &Args::default().score_cutoff(score + 0.0001)
+            )
         );
-        assert!(score >= 80.0); // Adjust based on expected partial token ratio
+
+        let accepted = ratio_with_args(
+            str1.chars(),
+            str2.chars(),
+            &Args::default().score_cutoff(score - 0.0001),
+        )
+        .unwrap();
+        assert_delta!(score, accepted);
     }
 
     #[test]
-    fn test_partial_token_ratio_with_args_no_common_tokens() {
-        let s1 = "abcdefghij";
-        let s2 = "klmnopqrst";
-        let args = Args::default();
-        let score = partial_token_ratio_with_args(
-            s1.chars().collect::<Vec<_>>(),
-            sorted_split(s1.chars()),
+    fn partial_ratio_basics() {
+        assert_delta!(1.0, partial_ratio("abcd".chars(), "xxabcdyy".chars(), 0.0));
+        assert_delta!(1.0, partial_ratio("".chars(), "".chars(), 0.0));
+        assert_delta!(0.0, partial_ratio("".chars(), "abc".chars(), 0.0));
+    }
+
+    #[test]
+    fn partial_ratio_alignment_swapped() {
+        let s1 = "abcd";
+        let s2 = "xxabcdyy";
+        let a1 = partial_ratio_alignment(
+            s1.chars(),
+            s1.chars().count(),
             s2.chars(),
-            &args,
+            s2.chars().count(),
+            &Args::default(),
         );
-        assert_eq!(score, 0.0);
-    }
-
-    #[test]
-    fn test_partial_token_ratio_with_args_all_common_tokens() {
-        let s1 = "the quick brown fox";
-        let s2 = "the quick brown fox";
-        let args = Args::default();
-        let score = partial_token_ratio_with_args(
-            s1.chars().collect::<Vec<_>>(),
-            sorted_split(s1.chars()),
+        let a2 = partial_ratio_alignment(
             s2.chars(),
-            &args,
+            s2.chars().count(),
+            s1.chars(),
+            s1.chars().count(),
+            &Args::default(),
         );
-        assert_eq!(score, 100.0);
+
+        assert_delta!(a1.score, a2.score);
+        assert_eq!(a1.src_start, a2.dest_start);
+        assert_eq!(a1.src_end, a2.dest_end);
+        assert_eq!(a1.dest_start, a2.src_start);
+        assert_eq!(a1.dest_end, a2.src_end);
     }
 
     #[test]
-    fn test_partial_token_ratio_with_args_partial_overlap_tokens() {
-        let s1 = "the quick brown fox jumps over the lazy dog";
-        let s2 = "quick fox lazy";
-        let args = Args::default();
-        let score = partial_token_ratio_with_args(
-            s1.chars().collect::<Vec<_>>(),
-            sorted_split(s1.chars()),
-            s2.chars(),
-            &args,
+    fn token_ratio_basics() {
+        let score = token_ratio_with_args(
+            "fuzzy wuzzy was a bear".chars(),
+            "wuzzy fuzzy was a bear".chars(),
+            &Args::default(),
         );
-        assert!(score == 100.0); // Adjust based on expected partial token ratio
-    }
-
-    // 5. Additional Tests for `wratio_with_args`
-    #[test]
-    fn test_wratio_with_args_identical_strings() {
-        let s1 = "good morning";
-        let s2 = "good morning";
-        let args = Args::default().score_cutoff(0.0);
-        let score = wratio_with_args(s1.chars(), s2.chars(), &args);
-        assert_eq!(score.unwrap(), 100.0);
+        assert_delta!(1.0, score);
     }
 
     #[test]
-    fn test_wratio_with_args_completely_different_strings() {
-        let s1 = "good morning";
-        let s2 = "bad evening";
-        let args = Args::default().score_cutoff(0.0);
-        let score = wratio_with_args(s1.chars(), s2.chars(), &args);
-        assert_eq!(score.unwrap(), 52.17391304347826);
-    }
-
-    #[test]
-    fn test_wratio_with_args_partial_match_high_cutoff() {
-        let s1 = "hello world";
-        let s2 = "hello there";
-        let args = Args::default().score_cutoff(70.0);
-        let score = wratio_with_args(s1.chars(), s2.chars(), &args);
-        assert!(score.is_none()); // Adjust based on expected behavior
-    }
-
-    #[test]
-    fn test_wratio_with_args_partial_match_low_cutoff() {
-        let s1 = "hello world";
-        let s2 = "hello there";
-        let args = Args::default().score_cutoff(50.0);
-        let score = wratio_with_args(s1.chars(), s2.chars(), &args);
-        assert!(score.unwrap() >= 50.0);
-    }
-
-    #[test]
-    fn test_wratio_with_args_with_score_hint() {
-        let s1 = "fuzzy wuzzy was a bear";
-        let s2 = "wuzzy fuzzy was a hare";
-        let args = Args::default().score_cutoff(70.0).score_hint(85.0);
-        let score = wratio_with_args(s1.chars(), s2.chars(), &args);
-        assert!(score.unwrap() >= 70.0); // Adjust based on expected behavior
-    }
-
-    #[test]
-    fn test_wratio_with_args_case_sensitive() {
-        let s1 = "Hello World";
-        let s2 = "hello world";
-        let args = Args::default().score_cutoff(0.00);
-        let score = wratio_with_args(s1.chars(), s2.chars(), &args);
-        assert!(score.unwrap() < 100.0);
-    }
-
-    #[test]
-    fn test_wratio_with_args_unicode_characters() {
-        let s1 = "こんにちは世界"; // "Hello World" in Japanese
-        let s2 = "こんにちは世界";
-        let args = Args::default().score_cutoff(0.0);
-        let score = wratio_with_args(s1.chars(), s2.chars(), &args);
-        assert_eq!(score.unwrap(), 100.0);
-    }
-
-    // 6. Additional Tests for `Args` Struct Methods
-    #[test]
-    fn test_args_score_hint() {
-        let args = Args::<f64, NoScoreCutoff>::default().score_hint(80.0);
-        assert_eq!(args.score_hint, Some(80.0));
-    }
-
-    #[test]
-    fn test_args_score_cutoff() {
-        let args = Args::<f64, NoScoreCutoff>::default().score_cutoff(75.0);
-        match args.score_cutoff {
-            WithScoreCutoff(cutoff) => assert_eq!(cutoff, 75.0),
-        }
-    }
-
-    #[test]
-    fn test_args_score_cutoff_and_hint() {
-        let args = Args::<f64, NoScoreCutoff>::default()
-            .score_hint(85.0)
-            .score_cutoff(90.0);
-        match args.score_cutoff {
-            WithScoreCutoff(cutoff) => assert_eq!(cutoff, 90.0),
-        }
-        assert_eq!(args.score_hint, Some(85.0));
-    }
-
-    // 7. Additional Tests for `RatioBatchComparator`
-    #[test]
-    fn test_ratio_batch_comparator_similar_strings() {
-        let comparator = RatioBatchComparator::new("this is a test".chars());
-        let score = comparator.similarity("this is a test!".chars());
-        assert!(score > 90.0); // Adjust based on actual expected score
-    }
-
-    #[test]
-    fn test_ratio_batch_comparator_completely_different_strings() {
-        let comparator = RatioBatchComparator::new("this is a test".chars());
-        let score = comparator.similarity("completely different".chars());
-        assert!(score < 50.0); // Adjust based on actual expected score
-    }
-
-    #[test]
-    fn test_ratio_batch_comparator_with_score_cutoff() {
-        let comparator = RatioBatchComparator::new("rust programming language".chars());
-        let args = Args::default().score_cutoff(80.0);
-        let score = comparator.similarity_with_args("rust lang".chars(), &args);
-        assert!(score.unwrap() >= 80.0); // Adjust based on expected behavior
-    }
-
-    #[test]
-    fn test_ratio_batch_comparator_empty_strings() {
-        let comparator = RatioBatchComparator::new("".chars());
-        let score = comparator.similarity("".chars());
-        assert_eq!(score, 100.0);
-
-        let score = comparator.similarity("non-empty".chars());
-        assert_eq!(score, 0.0);
-    }
-
-    // 8. Comprehensive Tests Covering All Functions
-    #[test]
-    fn test_comprehensive_wratio_flow() {
-        let s1 = "fuzzy wuzzy was a bear";
-        let s2 = "wuzzy fuzzy was a hare";
-
-        // Compute different ratios
-        let ratio = ratio(s1.chars(), s2.chars());
-        let partial_ratio = partial_ratio(s1.chars(), s2.chars(), 0.0);
-        let token_ratio = token_ratio_with_args(s1.chars(), s2.chars(), &Args::default());
-        let partial_token_ratio = partial_token_ratio(s1.chars(), s2.chars(), 0.0);
-
-        // Compute wratio
-        let wratio = wratio(s1.chars(), s2.chars(), 0.0);
-
-        // Validate that wratio is at least as good as the best individual ratio
-        let max_individual = ratio
-            .max(partial_ratio)
-            .max(token_ratio)
-            .max(partial_token_ratio);
-        assert!(wratio >= max_individual);
-    }
-
-    #[test]
-    fn test_comprehensive_ratio_with_score_cutoff() {
-        let s1 = "abcdefg";
-        let s2 = "abcxyzg";
-
-        let score = ratio(s1.chars(), s2.chars());
-
-        let high_cutoff_args = Args::default().score_cutoff(score + 0.1);
-        let low_cutoff_args = Args::default().score_cutoff(score - 0.1);
-
-        // With high cutoff, expect 0.0 if score is below cutoff
-        let high_score = ratio_with_args(s1.chars(), s2.chars(), &high_cutoff_args);
-        assert_eq!(high_score.unwrap(), 0.0);
-
-        // With low cutoff, expect the actual score
-        let low_score = ratio_with_args(s1.chars(), s2.chars(), &low_cutoff_args);
-        assert_eq!(low_score.unwrap(), score);
-    }
-
-    // 9. Edge Case Tests
-    #[test]
-    fn test_ratio_with_args_single_character() {
-        let s1 = "a";
-        let s2 = "a";
-        let args = Args::default();
-        let score = ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert_eq!(score, 100.0);
-    }
-
-    #[test]
-    fn test_ratio_with_args_single_character_different() {
-        let s1 = "a";
-        let s2 = "b";
-        let args = Args::default();
-        let score = ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert_eq!(score, 0.0);
-    }
-
-    #[test]
-    fn test_partial_ratio_with_args_single_character_substring() {
-        let s1 = "a";
-        let s2 = "abc";
-        let args = Args::default();
-        let score = partial_ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert_eq!(score, 100.0);
-    }
-
-    #[test]
-    fn test_token_ratio_with_args_empty_tokens() {
-        let s1 = "    "; // All spaces
-        let s2 = "    ";
-        let args = Args::default();
-        let score = token_ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert_eq!(score, 100.0);
-    }
-
-    #[test]
-    fn test_partial_token_ratio_with_args_repeated_tokens() {
-        let s1 = "apple apple banana";
-        let s2 = "apple banana banana";
-        let args = Args::default();
-        let score = partial_token_ratio_with_args(
-            s1.chars().collect::<Vec<_>>(),
-            sorted_split(s1.chars()),
-            s2.chars(),
-            &args,
+    fn partial_token_ratio_basics() {
+        let score = partial_token_ratio(
+            "fuzzy wuzzy was a bear".chars(),
+            "wuzzy fuzzy was a hare".chars(),
+            0.0,
         );
-        assert!(score > 70.0); // Adjust based on expected behavior
-    }
-
-    // 10. Tests with Various `score_cutoff` Values
-    #[test]
-    fn test_ratio_with_args_various_cutoffs() {
-        let s1 = "hello world";
-        let s2 = "hello there";
-
-        let score = ratio(s1.chars(), s2.chars());
-
-        // High cutoff, expect 0.0 if score is below cutoff
-        let args_high = Args::default().score_cutoff(score + 10.0);
-        let score_high = ratio_with_args(s1.chars(), s2.chars(), &args_high);
-        assert_eq!(score_high.unwrap(), 0.0);
-
-        // Exact cutoff, expect the actual score
-        let args_exact = Args::default().score_cutoff(score);
-        let score_exact = ratio_with_args(s1.chars(), s2.chars(), &args_exact);
-        assert_eq!(score_exact.unwrap(), score);
-
-        // Low cutoff, expect the actual score
-        let args_low = Args::default().score_cutoff(score - 10.0);
-        let score_low = ratio_with_args(s1.chars(), s2.chars(), &args_low);
-        assert_eq!(score_low.unwrap(), score);
-    }
-
-    // 11. Tests for Functions with Specific Behavior
-    #[test]
-    fn test_ratio_with_args_special_characters() {
-        let s1 = "hello, world!";
-        let s2 = "hello world";
-        let args = Args::default();
-        let score = ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert!(score > 80.0); // Adjust based on expected handling of punctuation
+        assert!(score > 0.85);
     }
 
     #[test]
-    fn test_token_ratio_with_args_multiple_spaces() {
-        let s1 = "hello   world";
-        let s2 = "hello world";
-        let args = Args::default();
-        let score = token_ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert_eq!(score, 100.0);
-    }
-
-    // 12. Tests for Non-ASCII Characters and Normalization
-    #[test]
-    fn test_ratio_with_args_non_ascii_characters() {
-        let s1 = "Café Münsterländer";
-        let s2 = "Cafe Munsterlander";
-        let args = Args::default();
-        let score = ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert!(score > 80.0); // Adjust based on Unicode normalization handling
-    }
-
-    #[test]
-    fn test_partial_token_ratio_with_args_reversed_strings() {
-        let s1 = "the cat in the hat";
-        let s2 = "hat the in cat the";
-        let args = Args::default();
-        let score = partial_token_ratio_with_args(
-            s1.chars().collect::<Vec<_>>(),
-            sorted_split(s1.chars()),
-            s2.chars(),
-            &args,
+    fn wratio_basics() {
+        let score = wratio(
+            "fuzzy wuzzy was a bear".chars(),
+            "wuzzy fuzzy was a bear".chars(),
+            0.0,
         );
-        assert_eq!(score, 100.0); // Tokens match despite order
-    }
-
-    // 13. Testing `score_cutoff_to_distance` and `norm_distance` Utility Functions
-    #[test]
-    fn test_score_cutoff_to_distance() {
-        let cutoff = 75.0;
-        let lensum = 100;
-        let distance = score_cutoff_to_distance(cutoff, lensum);
-        assert_eq!(distance, 25);
-    }
-
-    #[test]
-    fn test_norm_distance_above_cutoff() {
-        let dist = 20;
-        let lensum = 100;
-        let cutoff = 75.0;
-        let normalized = norm_distance(dist, lensum, cutoff);
-        assert_eq!(normalized, 80.0); // 100 - (20 / 100)*100 = 80
-    }
-
-    #[test]
-    fn test_norm_distance_below_cutoff() {
-        let dist = 30;
-        let lensum = 100;
-        let cutoff = 75.0;
-        let normalized = norm_distance(dist, lensum, cutoff);
-        assert_eq!(normalized, 0.0);
-    }
-
-    #[test]
-    fn test_norm_distance_exact_cutoff() {
-        let dist = 25;
-        let lensum = 100;
-        let cutoff = 75.0;
-        let normalized = norm_distance(dist, lensum, cutoff);
-        assert_eq!(normalized, 75.0);
-    }
-
-    #[test]
-    fn test_score_cutoff_to_distance_zero_cutoff() {
-        let cutoff = 0.0;
-        let lensum = 100;
-        let distance = score_cutoff_to_distance(cutoff, lensum);
-        assert_eq!(distance, 100);
-    }
-
-    #[test]
-    fn test_norm_distance_zero_lensum() {
-        let dist = 0;
-        let lensum = 0;
-        let cutoff = 50.0;
-        let normalized = norm_distance(dist, lensum, cutoff);
-        assert_eq!(normalized, 100.0);
-    }
-
-    // 14. Advanced Tests with `score_hint`
-    #[test]
-    fn test_ratio_with_args_with_score_hint() {
-        let s1 = "fuzzy wuzzy was a bear";
-        let s2 = "wuzzy fuzzy was a hare";
-        let args = Args::default().score_cutoff(60.0).score_hint(80.0);
-        let score = ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert!(score.unwrap() >= 60.0); // Adjust based on expected behavior
-    }
-
-    // 15. Testing with Different `CutoffType` Implementations
-    #[test]
-    fn test_ratio_with_args_no_score_cutoff() {
-        let s1 = "example string";
-        let s2 = "example string";
-        let args = Args::default(); // NoScoreCutoff
-        let score = ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert_eq!(score, 100.0);
-    }
-
-    #[test]
-    fn test_ratio_with_args_with_score_cutoff() {
-        let s1 = "example string";
-        let s2 = "example string modified";
-        let args = Args::default().score_cutoff(80.0);
-        let score = ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert!(score.unwrap() >= 80.0); // Adjust based on expected behavior
-    }
-
-    // 16. Ensuring `RatioBatchComparator` Reusability
-    #[test]
-    fn test_ratio_batch_comparator_multiple_similar_strings() {
-        let comparator = RatioBatchComparator::new("fuzzy wuzzy was a bear".chars());
-
-        let score1 = comparator.similarity("fuzzy wuzzy was a bear".chars());
-        assert_eq!(score1, 100.0);
-
-        let score2 = comparator.similarity("wuzzy fuzzy was a hare".chars());
-        assert!(score2 > 70.0); // Adjust based on expected score
-
-        let score3 = comparator.similarity("nothing similar".chars());
-        assert!(score3 < 50.0); // Adjust based on expected score
-    }
-
-    #[test]
-    fn test_ratio_batch_comparator_empty_strings_2() {
-        let comparator = RatioBatchComparator::new("".chars());
-
-        let score1 = comparator.similarity("".chars());
-        assert_eq!(score1, 100.0);
-
-        let score2 = comparator.similarity("non-empty".chars());
-        assert_eq!(score2, 0.0);
-    }
-
-    // 17. Testing Utility Functions
-    #[test]
-    fn test_score_cutoff_to_distance_2() {
-        let cutoff = 75.0;
-        let lensum = 100;
-        let distance = score_cutoff_to_distance(cutoff, lensum);
-        assert_eq!(distance, 25);
-    }
-
-    #[test]
-    fn test_norm_distance_above_cutoff_2() {
-        let dist = 20;
-        let lensum = 100;
-        let cutoff = 75.0;
-        let normalized = norm_distance(dist, lensum, cutoff);
-        assert_eq!(normalized, 80.0); // 100 - (20 / 100)*100 = 80
-    }
-
-    #[test]
-    fn test_norm_distance_below_cutoff_2() {
-        let dist = 30;
-        let lensum = 100;
-        let cutoff = 75.0;
-        let normalized = norm_distance(dist, lensum, cutoff);
-        assert_eq!(normalized, 0.0);
-    }
-
-    #[test]
-    fn test_norm_distance_exact_cutoff_2() {
-        let dist = 25;
-        let lensum = 100;
-        let cutoff = 75.0;
-        let normalized = norm_distance(dist, lensum, cutoff);
-        assert_eq!(normalized, 75.0);
-    }
-
-    #[test]
-    fn test_score_cutoff_to_distance_zero_cutoff_2() {
-        let cutoff = 0.0;
-        let lensum = 100;
-        let distance = score_cutoff_to_distance(cutoff, lensum);
-        assert_eq!(distance, 100);
-    }
-
-    #[test]
-    fn test_norm_distance_zero_lensum_2() {
-        let dist = 0;
-        let lensum = 0;
-        let cutoff = 50.0;
-        let normalized = norm_distance(dist, lensum, cutoff);
-        assert_eq!(normalized, 100.0);
-    }
-
-    // 18. Testing `Partial Token Ratio` with Different Token Counts
-    #[test]
-    fn test_partial_token_ratio_with_args_more_tokens_in_s1() {
-        let s1 = "apple orange banana grape";
-        let s2 = "apple banana";
-        let args = Args::default();
-        let score = partial_token_ratio_with_args(
-            s1.chars().collect::<Vec<_>>(),
-            sorted_split(s1.chars()),
-            s2.chars(),
-            &args,
-        );
-        assert!(score > 70.0); // Adjust based on expected behavior
-    }
-
-    #[test]
-    fn test_partial_token_ratio_with_args_more_tokens_in_s2() {
-        let s1 = "apple banana";
-        let s2 = "apple orange banana grape";
-        let args = Args::default();
-        let score = partial_token_ratio_with_args(
-            s1.chars().collect::<Vec<_>>(),
-            sorted_split(s1.chars()),
-            s2.chars(),
-            &args,
-        );
-        assert!(score > 70.0); // Adjust based on expected behavior
-    }
-
-    // 19. Testing `wratio` with Different Scoring Strategies
-    #[test]
-    fn test_wratio_with_args_high_similarity() {
-        let s1 = "The quick brown fox jumps over the lazy dog";
-        let s2 = "The quick brown fox leaps over the lazy dog";
-        let args = Args::default().score_cutoff(80.0);
-        let score = wratio_with_args(s1.chars(), s2.chars(), &args);
-        assert!(score.unwrap() >= 80.0); // Adjust based on expected similarity
-    }
-
-    #[test]
-    fn test_wratio_with_args_low_similarity() {
-        let s1 = "The quick brown fox jumps over the lazy dog";
-        let s2 = "Lorem ipsum dolor sit amet";
-        let args = Args::default().score_cutoff(50.0);
-        let score = wratio_with_args(s1.chars(), s2.chars(), &args);
-        assert_eq!(score.unwrap(), 0.0);
-    }
-
-    // 20. Ensuring Consistency Across the Module
-    #[test]
-    fn test_ratio_non_with_args_consistency() {
-        let s1 = "consistent test";
-        let s2 = "consistent test";
-        let score_default = ratio(s1.chars(), s2.chars());
-        let score_with_args = ratio_with_args(s1.chars(), s2.chars(), &Args::default());
-        assert_eq!(score_default, score_with_args);
-    }
-
-    #[test]
-    fn test_wratio_non_with_args_consistency() {
-        let s1 = "fuzzy wuzzy was a bear";
-        let s2 = "wuzzy fuzzy was a hare";
-        let score_default = wratio(s1.chars(), s2.chars(), 0.0);
-        let score_with_args =
-            wratio_with_args(s1.chars(), s2.chars(), &Args::default().score_cutoff(0.0));
-        assert_eq!(score_default, score_with_args.unwrap());
-    }
-
-    // 21. Additional Edge Cases
-    #[test]
-    fn test_ratio_with_args_special_characters_2() {
-        let s1 = "hello, world!";
-        let s2 = "hello world";
-        let args = Args::default();
-        let score = ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert!(score > 80.0); // Adjust based on expected handling of punctuation
-    }
-
-    #[test]
-    fn test_token_ratio_with_args_multiple_spaces_2() {
-        let s1 = "hello   world";
-        let s2 = "hello world";
-        let args = Args::default();
-        let score = token_ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert_eq!(score, 100.0);
-    }
-
-    #[test]
-    fn test_ratio_with_args_non_ascii_characters_2() {
-        let s1 = "Café Münsterländer";
-        let s2 = "Cafe Munsterlander";
-        let args = Args::default();
-        let score = ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert!(score > 80.0); // Adjust based on Unicode normalization handling
-    }
-
-    #[test]
-    fn test_partial_token_ratio_with_args_reversed_strings_2() {
-        let s1 = "the cat in the hat";
-        let s2 = "hat the in cat the";
-        let args = Args::default();
-        let score = partial_token_ratio_with_args(
-            s1.chars().collect::<Vec<_>>(),
-            sorted_split(s1.chars()),
-            s2.chars(),
-            &args,
-        );
-        assert_eq!(score, 100.0); // Tokens match despite order
-    }
-
-    // 22. Testing `RatioBatchComparator` Reusability
-    #[test]
-    fn test_ratio_batch_comparator_multiple_similar_strings_2() {
-        let comparator = RatioBatchComparator::new("fuzzy wuzzy was a bear".chars());
-
-        let score1 = comparator.similarity("fuzzy wuzzy was a bear".chars());
-        assert_eq!(score1, 100.0);
-
-        let score2 = comparator.similarity("wuzzy fuzzy was a hare".chars());
-        assert!(score2 > 70.0); // Adjust based on expected score
-
-        let score3 = comparator.similarity("nothing similar".chars());
-        assert!(score3 < 50.0); // Adjust based on expected score
-    }
-
-    #[test]
-    fn test_ratio_batch_comparator_empty_strings_3() {
-        let comparator = RatioBatchComparator::new("".chars());
-
-        let score1 = comparator.similarity("".chars());
-        assert_eq!(score1, 100.0);
-
-        let score2 = comparator.similarity("non-empty".chars());
-        assert_eq!(score2, 0.0);
-    }
-
-    // 23. Testing Utility Functions (Already covered above)
-
-    // 24. Testing `Partial Token Ratio` with Different Token Counts (Already covered above)
-
-    // 25. Testing `wratio` with Different Scoring Strategies (Already covered above)
-
-    // 26. Testing `RatioBatchComparator` Reusability (Already covered above)
-
-    // 27. Testing Utility Functions (Already covered above)
-
-    // 28. Testing `Partial Token Ratio` with Different Token Counts (Already covered above)
-
-    // 29. Testing `wratio` with Different Scoring Strategies (Already covered above)
-
-    // 30. Testing `Args` with Different Configurations
-    #[test]
-    fn test_args_combined_cutoff_and_hint() {
-        let s1 = "example string";
-        let s2 = "example string modified";
-        let args = Args::default().score_cutoff(80.0).score_hint(85.0);
-        let score = ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert!(score.unwrap() >= 80.0); // Adjust based on expected behavior
-    }
-
-    #[test]
-    fn test_args_only_score_cutoff() {
-        let s1 = "test string";
-        let s2 = "test string";
-        let args = Args::default().score_cutoff(90.0);
-        let score = ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert_eq!(score.unwrap(), 100.0); // Since strings are identical and >= cutoff
-    }
-
-    #[test]
-    fn test_args_only_score_hint() {
-        let s1 = "test string";
-        let s2 = "test string modified";
-        let args = Args::default().score_hint(90.0);
-        let score = ratio_with_args(s1.chars(), s2.chars(), &args);
-        // Depending on implementation, score_hint might guide the scoring
-        // For example, if the similarity is >= score_hint, it might prioritize or short-circuit
-        // Adjust the assertion accordingly
-        assert!(score >= 90.0 || score == 0.0); // Depending on implementation
-    }
-
-    #[test]
-    fn test() {
-        let s1 = "test string";
-        let s2 = "test string";
-        let score_ratio = ratio(s1.chars(), s2.chars());
-        let score_partial_ratio = partial_ratio(s1.chars(), s2.chars(), 0.00);
-        println!("{}", score_ratio);
-        println!("{}", score_partial_ratio);
+        assert!(score > 0.9);
     }
 }

--- a/src/fuzz.rs
+++ b/src/fuzz.rs
@@ -4,7 +4,7 @@ use crate::common::{
 use crate::details::distance::MetricUsize;
 use crate::details::splitted_sentence::{IsSpace, SplittedSentence};
 use crate::distance::indel;
-use crate::HashableChar; // assuming this is where ratio_with_args is located
+use crate::HashableChar;
 
 pub fn score_cutoff_to_distance(score_cutoff: f64, lensum: usize) -> usize {
     ((lensum as f64) * (1.0 - score_cutoff / 100.0)).ceil() as usize
@@ -873,7 +873,7 @@ mod tests {
         let s2 = "hello world";
         let args = Args::default();
         let score = ratio_with_args(s1.chars(), s2.chars(), &args) * 100.00;
-        assert!(score < 100.0); // Assuming case-sensitive
+        assert!(score < 100.0);
     }
 
     #[test]
@@ -956,9 +956,6 @@ mod tests {
         let s2 = "quick brown fox";
         let args = Args::default();
         let score = token_ratio_with_args(s1.chars(), s2.chars(), &args);
-        // Depending on implementation, adjust the expectation
-        // If case-insensitive: assert_eq!(score, 100.0);
-        // If case-sensitive: assert_eq!(score, 100.0); // Assuming tokens are matched regardless of case
         assert!(score >= 100.0 || score < 100.0); // Placeholder
     }
 
@@ -1071,7 +1068,7 @@ mod tests {
         let s2 = "hello world";
         let args = Args::default().score_cutoff(0.00);
         let score = wratio_with_args(s1.chars(), s2.chars(), &args);
-        assert!(score.unwrap() < 100.0); // Assuming case-sensitive
+        assert!(score.unwrap() < 100.0);
     }
 
     #[test]
@@ -1275,7 +1272,7 @@ mod tests {
         let s2 = "hello world";
         let args = Args::default();
         let score = token_ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert_eq!(score, 100.0); // Assuming multiple spaces are treated as single tokens
+        assert_eq!(score, 100.0);
     }
 
     // 12. Tests for Non-ASCII Characters and Normalization
@@ -1547,7 +1544,7 @@ mod tests {
         let s2 = "hello world";
         let args = Args::default();
         let score = token_ratio_with_args(s1.chars(), s2.chars(), &args);
-        assert_eq!(score, 100.0); // Assuming multiple spaces are treated as single tokens
+        assert_eq!(score, 100.0);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub mod distance;
 pub mod fuzz;
 
 /// Hash value in the range `i64::MIN` - `u64::MAX`
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, std::hash::Hash)]
 pub enum Hash {
     UNSIGNED(u64),
     SIGNED(i64),


### PR DESCRIPTION
This PR attempts the addition of all functionality required for the addition of WRatio which includes:

- `token_ratio`
- `partial_ratio`
- `partial_token_ratio` 
- `wratio` 
- and some lower-level dependencies of these functions.

Additionally, lots of test cases were added. (Many of which don't pass yet (Sometimes the tests themself make wrong assumptions, but they are a good base for further debugging.)

This PR should not be merged yet. 

One major issue is that, because the ratio function returns in the range from 0-1 and the other newly implemented ratio functions return between 0-100, like in the C++ implementation, hence the score_cutoff parameter doesn't work properly yet. 

However, with score_cutoff set to 0, the functions seem to return the same values as in the C++ reference implementation.

I have opened this PR because I'm not sure if I will have time to further work on this - I think the current, very sloppy state of the implementation in this PR is already sufficient for my use case for now.
